### PR TITLE
Tela de consulta de clientes semi-finalizada

### DIFF
--- a/front-end/src/app/features/manager/manager.routes.ts
+++ b/front-end/src/app/features/manager/manager.routes.ts
@@ -1,4 +1,5 @@
 import {Routes} from '@angular/router';
+import { ConsultarClientesComponent } from './pages/consultar-clientes/consultar-clientes';
 
 export const managerRoutes: Routes = [
     /* 
@@ -8,4 +9,8 @@ export const managerRoutes: Routes = [
       component: ManagerHomePageComponent,
     }
     */
+     { 
+       path: 'consultar-clientes',
+       component: ConsultarClientesComponent,
+     },
 ];

--- a/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.css
+++ b/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.css
@@ -1,0 +1,152 @@
+main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xl);
+  padding-top: var(--spacing-xl);
+}
+
+.cor-titulo {
+  color: var(--color-neutral-800);
+}
+
+.cor-subtitulo {
+  color: var(--color-neutral-600);
+}
+
+.container-filtro {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-md);
+}
+
+.controles-filtro {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.entrada-selecao, .entrada-busca {
+  height: 48px;
+  border: 1px solid var(--color-border-alternative);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--spacing-sm);
+  background-color: var(--color-card);
+  color: var(--color-foreground);
+  outline: none;
+}
+
+.entrada-selecao:focus, .entrada-busca:focus {
+  border-color: var(--color-ring);
+}
+
+.entrada-selecao {
+  width: 150px;
+  cursor: pointer;
+}
+
+.envoltorio-busca {
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+}
+
+.entrada-busca {
+  width: 100%;
+  padding-right: var(--spacing-xl);
+}
+
+.icone-busca {
+  position: absolute;
+  right: var(--spacing-sm);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  color: var(--color-neutral-400);
+  stroke-width: 2;
+  pointer-events: none;
+}
+
+/* ESTILOS DA TABELA */
+.container-tabela {
+  width: 100%;
+  overflow-x: auto;
+  background-color: var(--color-card);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+.tabela-clientes {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.tabela-clientes th, .tabela-clientes td {
+  padding: var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tabela-clientes thead {
+  background-color: var(--color-primary);
+}
+
+.tabela-clientes th {
+  color: var(--color-primary-foreground);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+}
+
+.linha-tabela {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  color: var(--color-foreground);
+}
+
+.linha-tabela:hover {
+  background-color: var(--layout-table-row-light);
+}
+
+.estado-vazio {
+  text-align: center;
+  color: var(--color-muted-foreground);
+  padding: var(--spacing-2xl) !important;
+}
+
+/* ESTILOS DA PAGINAÇÃO */
+.controles-paginacao {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-card);
+}
+
+.texto-paginacao {
+  color: var(--color-neutral-600);
+}
+
+.botao-paginacao {
+  background-color: transparent;
+  color: var(--color-primary);
+  border: 1px solid var(--color-border-alternative);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-2xs) var(--spacing-sm);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.botao-paginacao:hover:not(:disabled) {
+  background-color: var(--color-primary-foreground);
+  border-color: var(--color-primary);
+}
+
+.botao-paginacao:disabled {
+  color: var(--color-neutral-300);
+  border-color: var(--color-border);
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.html
+++ b/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.html
@@ -1,0 +1,89 @@
+<main>
+  <div class="secao-cabecalho">
+    <h1 class="heading_2 cor-titulo">Consulta de Clientes</h1>
+    
+    <div class="container-filtro">
+      <label class="label_large cor-subtitulo">Filtrar por:</label>
+      
+      <div class="controles-filtro">
+        <select class="body_medium entrada-selecao" [(ngModel)]="tipoFiltro" (change)="onTipoFiltroChange()">
+          <option value="nome">Nome</option>
+          <option value="cpf">CPF</option>
+        </select>
+
+        <div class="envoltorio-busca">
+          <input 
+            type="text" 
+            class="body_medium entrada-busca" 
+            [placeholder]="tipoFiltro === 'nome' ? 'Pesquisar por nome...' : 'Pesquisar por CPF...'"
+            [(ngModel)]="termoBusca"
+            (input)="onBuscaInput($event)"
+            [maxlength]="tipoFiltro === 'cpf' ? 14 : 100"
+          >
+          <svg class="icone-busca" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container-tabela">
+    <table class="tabela-clientes">
+      <thead>
+        <tr class="label_large">
+          <th>CPF</th>
+          <th>Nome</th>
+          <th>Cidade</th>
+          <th>Estado</th>
+          <th>Saldo da Conta</th>
+          <th>Limite da Conta</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (cliente of clientesPaginados; track cliente.id) {
+          <tr 
+            class="body_small linha-tabela"
+            [routerLink]="['/gerente/cliente', cliente.id]"
+          >
+            <td>{{ cliente.cpf }}</td>
+            <td>{{ cliente.nome }}</td>
+            <td>{{ cliente.cidade }}</td>
+            <td>{{ cliente.estado }}</td>
+            <td>{{ cliente.saldo | currency:'BRL' }}</td>
+            <td>{{ cliente.limite | currency:'BRL' }}</td>
+          </tr>
+        }
+
+        @if (clientesExibidos.length === 0) {
+          <tr>
+            <td colspan="6" class="body_medium estado-vazio">Nenhum cliente encontrado.</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    @if (clientesExibidos.length > 0) {
+      <div class="controles-paginacao">
+        <button 
+          class="botao-paginacao label_medium" 
+          (click)="paginaAnterior()" 
+          [disabled]="paginaAtual === 1">
+          Anterior
+        </button>
+        
+        <span class="texto-paginacao body_small">
+          Página {{ paginaAtual }} de {{ totalPaginas }}
+        </span>
+        
+        <button 
+          class="botao-paginacao label_medium" 
+          (click)="proximaPagina()" 
+          [disabled]="paginaAtual === totalPaginas">
+          Próxima
+        </button>
+      </div>
+    }
+  </div>
+</main>

--- a/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.spec.ts
+++ b/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConsultarClientes } from './consultar-clientes';
+
+describe('ConsultarClientes', () => {
+  let component: ConsultarClientes;
+  let fixture: ComponentFixture<ConsultarClientes>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConsultarClientes]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ConsultarClientes);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.ts
+++ b/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.ts
@@ -1,0 +1,129 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+export interface Cliente {
+  id: string;
+  cpf: string;
+  nome: string;
+  cidade: string;
+  estado: string;
+  saldo: number;
+  limite: number;
+}
+
+@Component({
+  selector: 'app-consultar-clientes',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './consultar-clientes.html',
+  styleUrls: ['./consultar-clientes.css']
+})
+export class ConsultarClientesComponent implements OnInit {
+  
+  tipoFiltro: 'nome' | 'cpf' = 'nome';
+  termoBusca: string = '';
+
+  // Configurações de Paginação
+  paginaAtual: number = 1;
+  itensPorPagina: number = 5;
+  clientesPaginados: Cliente[] = [];
+
+  // Dados de exemplo
+  clientes: Cliente[] = [
+    { id: '1', cpf: '111.111.111-11', nome: 'Gabriel de Paula Brasil', cidade: 'Curitiba', estado: 'Paraná', saldo: 1500.50, limite: 5000 },
+    { id: '2', cpf: '222.222.222-22', nome: 'Amanda Silva', cidade: 'São Paulo', estado: 'São Paulo', saldo: 250.00, limite: 1000 },
+    { id: '3', cpf: '333.333.333-33', nome: 'Carlos Eduardo', cidade: 'Pinhais', estado: 'Paraná', saldo: 8500.00, limite: 15000 },
+    { id: '4', cpf: '444.444.444-44', nome: 'Beatriz Costa', cidade: 'Colombo', estado: 'Paraná', saldo: 120.00, limite: 500 },
+    { id: '5', cpf: '555.555.555-55', nome: 'Daniel Souza', cidade: 'Londrina', estado: 'Paraná', saldo: 3000.00, limite: 6000 },
+    { id: '6', cpf: '666.666.666-66', nome: 'Eduarda Lima', cidade: 'Maringá', estado: 'Paraná', saldo: 450.00, limite: 1500 }
+  ];
+
+  clientesExibidos: Cliente[] = [];
+
+  ngOnInit(): void {
+    this.ordenarClientesPorNome();
+    this.clientesExibidos = [...this.clientes];
+    this.atualizarPaginacao();
+  }
+
+  get totalPaginas(): number {
+    return Math.ceil(this.clientesExibidos.length / this.itensPorPagina);
+  }
+
+  ordenarClientesPorNome(): void {
+    this.clientes.sort((a, b) => a.nome.localeCompare(b.nome));
+  }
+
+  filtrarClientes(): void {
+    if (!this.termoBusca.trim()) {
+      this.clientesExibidos = [...this.clientes];
+    } else {
+      const termo = this.termoBusca.toLowerCase().trim();
+
+      this.clientesExibidos = this.clientes.filter(cliente => {
+        if (this.tipoFiltro === 'nome') {
+          return cliente.nome.toLowerCase().includes(termo);
+        } else {
+          const cpfLimpo = cliente.cpf.replace(/\D/g, '');
+          const termoLimpo = termo.replace(/\D/g, '');
+          return cpfLimpo.includes(termoLimpo) || cliente.cpf.includes(termo);
+        }
+      });
+    }
+    
+    // Sempre que filtrar, volta para a primeira página
+    this.paginaAtual = 1;
+    this.atualizarPaginacao();
+  }
+
+  // --- LÓGICA DE PAGINAÇÃO ---
+  atualizarPaginacao(): void {
+    const indiceInicio = (this.paginaAtual - 1) * this.itensPorPagina;
+    const indiceFim = indiceInicio + this.itensPorPagina;
+    this.clientesPaginados = this.clientesExibidos.slice(indiceInicio, indiceFim);
+  }
+
+  paginaAnterior(): void {
+    if (this.paginaAtual > 1) {
+      this.paginaAtual--;
+      this.atualizarPaginacao();
+    }
+  }
+
+  proximaPagina(): void {
+    if (this.paginaAtual < this.totalPaginas) {
+      this.paginaAtual++;
+      this.atualizarPaginacao();
+    }
+  }
+
+  onBuscaInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    let valor = input.value;
+
+    if (this.tipoFiltro === 'cpf') {
+      valor = valor.replace(/\D/g, ''); // Remove tudo que não for número
+
+      if (valor.length > 11) valor = valor.slice(0, 11);
+      if (valor.length > 9) valor = valor.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+      else if (valor.length > 6) valor = valor.replace(/(\d{3})(\d{3})(\d{1,3})/, '$1.$2.$3');
+      else if (valor.length > 3) valor = valor.replace(/(\d{3})(\d{1,3})/, '$1.$2');
+      
+    } else if (this.tipoFiltro === 'nome') {
+      valor = valor.replace(/\d/g, ''); 
+    }
+
+    this.termoBusca = valor;
+    input.value = valor;
+    
+    this.filtrarClientes();
+  }
+
+  onTipoFiltroChange(): void {
+    this.termoBusca = '';
+    this.filtrarClientes();
+  }
+
+}


### PR DESCRIPTION
Descrição:
Semi-finalizado pois ainda não usei o mock-server do Edũ. 

Tipo de mudança:
- Feature

Guia de Testes:
Rodar ng serve na página http://localhost:4200/manager/consultar-clientes para simular a listagem de clientes.

Resultado esperado:
Poder filtrar os clientes por nome e/ou CPF, não permite digitar números ao filtrar por nome, nem letras ao pesquisar por CPF. Ao clicar em alguma linha contendo o cliente, o sistema redireciona para o caminho http://localhost:4200/gerente/cliente/{id}, e como essa parte não está pronta o resultado esperado é o famoso né... 404!