### PR TITLE
[FRONTEND] [R11 - RejeitarCliente - v2]

### DIFF
--- a/front-end/mock-server.js
+++ b/front-end/mock-server.js
@@ -114,8 +114,7 @@ app.post("/auth/register", (req, res) => {
   });
 });
 
-//Rejeitar Cliente ---------------------------------------
-//Rejeição de clientes ---------------------------------
+//Rejeição de Cliente ---------------------------------------
 app.post("/manager/rejeitar-cliente/:cpf", (req, res) => {
   const cpf = req.params.cpf;
   const { motivo } = req.body; 
@@ -127,7 +126,6 @@ app.post("/manager/rejeitar-cliente/:cpf", (req, res) => {
     return res.status(404).json({ message: "Pedido não encontrado" });
   }
 
-  // 1. CRIAMOS A VARIÁVEL BEM AQUI (Fora de qualquer 'if')
   const dataHoraRejeicao = new Date().toISOString(); 
 
   const novasSolicitacoes = solicitacoes.filter((s) => s.cpf !== cpf);
@@ -135,10 +133,8 @@ app.post("/manager/rejeitar-cliente/:cpf", (req, res) => {
 
   console.log(`Pedido de ${pedido.email} rejeitado. Motivo: ${motivo}`);
   
-  // 2. USAMOS ELA AQUI NO LOG
   console.log(`Data/Hora da Rejeição armazenada: ${dataHoraRejeicao}`);
 
-  // 3. E USAMOS ELA AQUI NA RESPOSTA
   res.json({
     message: "Cliente rejeitado com sucesso",
     dataRejeicao: dataHoraRejeicao

--- a/front-end/mock-server.js
+++ b/front-end/mock-server.js
@@ -114,6 +114,38 @@ app.post("/auth/register", (req, res) => {
   });
 });
 
+//Rejeitar Cliente ---------------------------------------
+//Rejeição de clientes ---------------------------------
+app.post("/manager/rejeitar-cliente/:cpf", (req, res) => {
+  const cpf = req.params.cpf;
+  const { motivo } = req.body; 
+
+  const solicitacoes = getData("solicitacoes");
+  const pedido = solicitacoes.find((s) => s.cpf === cpf);
+
+  if (!pedido) {
+    return res.status(404).json({ message: "Pedido não encontrado" });
+  }
+
+  // 1. CRIAMOS A VARIÁVEL BEM AQUI (Fora de qualquer 'if')
+  const dataHoraRejeicao = new Date().toISOString(); 
+
+  const novasSolicitacoes = solicitacoes.filter((s) => s.cpf !== cpf);
+  saveData("solicitacoes", novasSolicitacoes);
+
+  console.log(`Pedido de ${pedido.email} rejeitado. Motivo: ${motivo}`);
+  
+  // 2. USAMOS ELA AQUI NO LOG
+  console.log(`Data/Hora da Rejeição armazenada: ${dataHoraRejeicao}`);
+
+  // 3. E USAMOS ELA AQUI NA RESPOSTA
+  res.json({
+    message: "Cliente rejeitado com sucesso",
+    dataRejeicao: dataHoraRejeicao
+  });
+});
+
+
 //Listar pedidos ---------------------------------------
 app.get("/manager/pedidos-autocadastro", (_req, res) => {
 

--- a/front-end/src/app/features/manager/services/pedidos-autocadastro.ts
+++ b/front-end/src/app/features/manager/services/pedidos-autocadastro.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, delay, map, of } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { API_URL } from '../../../core/configs/api.token';
 import { PedidoAutocadastro } from '../../../shared/models/pedido-autocadastro';
 import { Client } from '../../../shared/models/client';
@@ -52,9 +52,8 @@ export class PedidosAutocadastroService {
     );
   }
 
-  rejeitar(cpf: string, motivo: string): Observable<boolean> {
-    console.log(`Rejeitando CPF: ${cpf} pelo motivo: ${motivo}`);
-    return of(true).pipe(delay(500));
+  rejeitar(cpf: string, motivo: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/manager/rejeitar-cliente/${cpf}`, { motivo });
   }
 
   aprovar(cpf: string) {


### PR DESCRIPTION
## 📝 Descrição
Implementação completa do Requisito 11, incluindo a correção apontada na revisão anterior referente à persistência dos dados e captura de data/hora.

**O que foi feito:**
- **Front-end:** Atualização do `PedidosAutocadastroService` para integrar com a nova rota do mock server via HTTP POST.
- **Mock Server** Criação da rota `POST /manager/rejeitar-cliente/:cpf` no `mock-server.js`.
- **Correção (Feedback da Revisão):** A lógica de rejeição foi transferida para o `mock-server.js`. Agora, o cliente rejeitado é removido do arquivo `solicitacoes.json` e a data/hora exata da rejeição passa a ser capturada e exibida no console do servidor.

## 🛠 Tipo de Mudança
- 🐛 **FIX**: Correção de bug.

## 🧪 Guia de Testes
**Como reproduzir:**
1. rode o comando `node mock-server.js`.
2. rode o comando `ng serve`.
3. Acesse a rota `http://localhost:4200/gerente/pedidos-autocadastro` no navegador.
4. Clique no botão "Rejeitar" de qualquer pedido listado.
6. Preencha um motivo com mais de 10 caracteres e clique em "Confirmar Rejeição".
7. Recarregue a página (F5).

**Resultado esperado:**
- O modal deve fechar automaticamente após a confirmação.
- O card do cliente deve sumir da lista visualmente.
- Ao dar F5, o cliente **não deve** reaparecer na lista.
- No terminal do `mock-server.js`, deve aparecer um log confirmando a rejeição, o motivo digitado, o e-mail simulado e a **Data/Hora da Rejeição armazenada**.

## 📸 Screenshots
<img width="1177" height="559" alt="Captura de tela 2026-03-20 183835" src="https://github.com/user-attachments/assets/b5e17e89-c188-4b67-95a5-26fbc72aa7fb" />
