### PR TITLE
[FRONTEND] 16 Relatório de Clientes

### DIFF
--- a/front-end/mock/conta-banco.json
+++ b/front-end/mock/conta-banco.json
@@ -8,6 +8,7 @@
     "availableBalance": 7825450.75,
     "limit": 5000,
     "manager": "João da Silva",
+    "managerDocument": "11122233344",
     "transactions": []
   },
   {
@@ -19,6 +20,7 @@
     "availableBalance": 2145320.50,
     "limit": 4000,
     "manager": "João da Silva",
+    "managerDocument": "11122233344",
     "transactions": []
   },
   {
@@ -30,6 +32,7 @@
     "availableBalance": 5632890.25,
     "limit": 10000,
     "manager": "João da Silva",
+    "managerDocument": "11122233344",
     "transactions": []
   },
   {
@@ -41,6 +44,7 @@
     "availableBalance": 892150.99,
     "limit": 3000,
     "manager": "Maria Santos",
+    "managerDocument": "55566677788",
     "transactions": []
   },
   {
@@ -52,6 +56,7 @@
     "availableBalance": 4521330.40,
     "limit": 7000,
     "manager": "Maria Santos",
+    "managerDocument": "55566677788",
     "transactions": []
   },
   {
@@ -63,6 +68,7 @@
     "availableBalance": 3215670.80,
     "limit": 5000,
     "manager": "João da Silva",
+    "managerDocument": "11122233344",
     "transactions": []
   }
 ]

--- a/front-end/mock/gerentes.json
+++ b/front-end/mock/gerentes.json
@@ -18,5 +18,19 @@
     "celular": "(13) 99676-2377",
     "senha": "123456",
     "tipo": "GERENTE"
+  },
+  {
+    "nome": "João da Silva",
+    "cpf": "11122233344",
+    "email": "joao.silva@bantads.com.br",
+    "celular": "(41) 98888-1111",
+    "tipo": "GERENTE"
+  },
+  {
+    "nome": "Maria Santos",
+    "cpf": "55566677788",
+    "email": "maria.santos@bantads.com.br",
+    "celular": "(41) 98888-2222",
+    "tipo": "GERENTE"
   }
 ]

--- a/front-end/src/app/features/admin/admin.routes.ts
+++ b/front-end/src/app/features/admin/admin.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { ListagemGerentesComponent } from './pages/listagem-gerentes/listagem-gerentes';
+import { RelatorioClientesComponent } from './pages/relatorio-clientes/relatorio-clientes';
 
 export const adminRoutes: Routes = [
   {
@@ -16,4 +17,9 @@ export const adminRoutes: Routes = [
     path: 'listar-gerentes',
     component: ListagemGerentesComponent,
   },
+
+  {
+    path: 'relatorio-clientes',
+    component: RelatorioClientesComponent,
+  }
 ];

--- a/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.css
+++ b/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.css
@@ -1,0 +1,135 @@
+:host {
+  display: block;
+}
+
+.relatorio-clientes {
+  width: 100%;
+  min-height: 100vh;
+  padding: 52px 0 48px;
+  background: var(--color-background, #e5e8e6);
+}
+
+.painel-relatorio {
+  width: min(1300px, calc(100% - 80px)); /* Mais largo para caber as 9 colunas */
+  min-height: 717px;
+  margin: 0 auto;
+  padding: 48px 28px;
+  border-radius: var(--border-lg, 24px);
+  background: var(--color-card, #fafafa);
+  display: flex;
+  flex-direction: column;
+  gap: 32px; 
+}
+
+.painel-relatorio__cabecalho h1 {
+  color: var(--color-foreground-title, #414946);
+  line-height: 36px;
+}
+
+.mt-2 {
+  margin-top: 8px;
+}
+
+.tabela-bloco {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tabela-container {
+  width: 100%;
+  border: 1px solid var(--color-border, #cdd4d1);
+  border-radius: var(--border-md, 16px);
+  background: var(--color-card, #fafafa);
+  overflow-x: auto; /* Adiciona barra de rolagem horizontal se a tela for pequena */
+}
+
+.tabela-relatorio {
+  width: 100%;
+  min-width: 1200px; /* Evita que as colunas fiquem esmagadas */
+  table-layout: auto;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.tabela-relatorio th {
+  height: 44px;
+  padding: 0 16px;
+  border: none;
+  background: var(--color-primary, #087448);
+  color: var(--color-primary-foreground, #edfcf3);
+  text-align: left;
+  vertical-align: middle;
+  font-family: var(--label-small-font-family);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+}
+
+.tabela-relatorio th:first-child {
+  border-top-left-radius: 15px;
+}
+
+.tabela-relatorio th:last-child {
+  border-top-right-radius: 15px;
+}
+
+.tabela-relatorio td {
+  height: 80px;
+  padding: 0 16px;
+  border-top: 1px solid var(--color-border, #cdd4d1);
+  color: var(--color-muted-foreground, #65756d);
+  background: var(--color-card, #fafafa);
+  vertical-align: middle;
+  font-family: var(--body-small-font-family);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.tabela-relatorio tr.mat-mdc-row:nth-child(odd) td {
+  background: #fbfcfb;
+}
+
+/* Regras visuais baseadas no Figma */
+.text-highlight-green {
+  color: var(--color-green-700, #087448) !important;
+  font-weight: var(--font-weight-bold) !important;
+}
+
+.text-highlight-red {
+  color: var(--color-destructive, #e01300) !important;
+  font-weight: var(--font-weight-bold) !important;
+}
+
+.mensagem-status {
+  padding: 20px 24px;
+  border: 1px solid var(--color-border, #cdd4d1);
+  border-radius: var(--border-md, 16px);
+  background: var(--color-card, #fafafa);
+  color: var(--color-foreground-title, #414946);
+}
+
+.mensagem-status--erro {
+  border-color: var(--color-red-200, #ffa2a1);
+  color: var(--color-red-400, #e01300);
+}
+
+.sem-dados {
+  height: 80px;
+  text-align: center;
+  color: var(--color-foreground-title, #414946);
+}
+
+.rodape-tabela {
+  padding: 16px 24px;
+  border: 1px solid var(--color-border, #cdd4d1);
+  border-radius: var(--border-md, 16px);
+  background: var(--color-card, #fafafa);
+  display: flex;
+  justify-content: flex-start;
+}
+
+/* Limpeza visual dos headers ordenáveis do Angular Material */
+:host ::ng-deep .tabela-relatorio .mat-sort-header-container { align-items: center; }
+:host ::ng-deep .tabela-relatorio .mat-sort-header-content { color: inherit; }
+:host ::ng-deep .tabela-relatorio .mat-sort-header-arrow { display: none; }

--- a/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.html
+++ b/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.html
@@ -1,0 +1,95 @@
+<main class="relatorio-clientes">
+  <section class="painel-relatorio">
+    <header class="painel-relatorio__cabecalho">
+      <h1 class="heading_3">Relatório de Clientes</h1>
+      <p class="body_medium color-muted-foreground mt-2">
+        Análise detalhada da base de clientes, saldos e limites de crédito segmentados.
+      </p>
+    </header>
+
+    @if (mensagemErro()) {
+      <p class="mensagem-status mensagem-status--erro body_medium">
+        {{ mensagemErro() }}
+      </p>
+    } @else if (carregando()) {
+      <p class="mensagem-status body_medium">Gerando relatório de clientes...</p>
+    } @else {
+      <div class="tabela-bloco">
+        <div class="tabela-container">
+          <table
+            mat-table
+            [dataSource]="fonteDados"
+            matSort
+            matSortActive="nomeCliente"
+            matSortDirection="asc"
+            matSortDisableClear
+            class="tabela-relatorio"
+          >
+            <ng-container matColumnDef="cpfCliente">
+              <th mat-header-cell *matHeaderCellDef>CPF DO CLIENTE</th>
+              <td mat-cell *matCellDef="let row">{{ formatarCpf(row.cpfCliente) }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="nomeCliente">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>NOME DO CLIENTE</th>
+              <td mat-cell *matCellDef="let row" class="text-highlight-green">{{ row.nomeCliente }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="emailCliente">
+              <th mat-header-cell *matHeaderCellDef>E-MAIL DO CLIENTE</th>
+              <td mat-cell *matCellDef="let row">{{ row.emailCliente }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="salario">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>SALÁRIO</th>
+              <td mat-cell *matCellDef="let row">{{ row.salario | currency:'BRL':'symbol':'1.2-2' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="numeroConta">
+              <th mat-header-cell *matHeaderCellDef>NÚMERO DA CONTA</th>
+              <td mat-cell *matCellDef="let row">{{ row.numeroConta }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="saldo">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>SALDO</th>
+              <td mat-cell *matCellDef="let row" 
+                  [ngClass]="row.saldo >= 0 ? 'text-highlight-green' : 'text-highlight-red'">
+                {{ row.saldo | currency:'BRL':'symbol':'1.2-2' }}
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="limite">
+              <th mat-header-cell *matHeaderCellDef>LIMITE DO CLIENTE</th>
+              <td mat-cell *matCellDef="let row">{{ row.limite | currency:'BRL':'symbol':'1.2-2' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="cpfGerente">
+              <th mat-header-cell *matHeaderCellDef>CPF DO GERENTE</th>
+              <td mat-cell *matCellDef="let row">{{ formatarCpf(row.cpfGerente) }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="nomeGerente">
+              <th mat-header-cell *matHeaderCellDef>NOME DO GERENTE</th>
+              <td mat-cell *matCellDef="let row">{{ row.nomeGerente }}</td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="colunasExibidas"></tr>
+            <tr mat-row *matRowDef="let row; columns: colunasExibidas"></tr>
+            
+            <tr *matNoDataRow>
+              <td class="sem-dados body_medium" [attr.colspan]="colunasExibidas.length">
+                Nenhum dado encontrado para o relatório.
+              </td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="rodape-tabela">
+          <span class="body_small color-muted-foreground">
+            Exibindo {{ fonteDados.data.length }} registros
+          </span>
+        </div>
+      </div>
+    }
+  </section>
+</main>

--- a/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.ts
+++ b/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.ts
@@ -1,0 +1,119 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  ViewChild,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { forkJoin } from 'rxjs';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+
+// Interface para tipar os dados da nossa tabela
+export interface RelatorioCliente {
+  cpfCliente: string;
+  nomeCliente: string;
+  emailCliente: string;
+  salario: number;
+  numeroConta: string;
+  saldo: number;
+  limite: number;
+  cpfGerente: string;
+  nomeGerente: string;
+}
+
+@Component({
+  selector: 'app-relatorio-clientes',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatSortModule,
+    MatTableModule
+  ],
+  templateUrl: './relatorio-clientes.html',
+  styleUrl: './relatorio-clientes.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RelatorioClientesComponent implements OnInit, AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly http = inject(HttpClient);
+
+  @ViewChild(MatSort) private ordenador!: MatSort;
+
+  // As 9 colunas exigidas pelo protótipo
+  readonly colunasExibidas = [
+    'cpfCliente', 'nomeCliente', 'emailCliente', 'salario', 
+    'numeroConta', 'saldo', 'limite', 'cpfGerente', 'nomeGerente'
+  ];
+  
+  // Controle de estado da tela usando Signals
+  readonly carregando = signal(true);
+  readonly mensagemErro = signal('');
+  readonly fonteDados = new MatTableDataSource<RelatorioCliente>([]);
+
+  ngOnInit(): void {
+    this.carregarRelatorio();
+  }
+
+  ngAfterViewInit(): void {
+    this.fonteDados.sort = this.ordenador;
+  }
+
+  // Reaproveitado a máscara de CPF
+  formatarCpf(cpf: string): string {
+    if (!cpf || cpf === '-') return '-';
+    const cpfNormalizado = cpf.replace(/\D/g, '');
+    if (cpfNormalizado.length !== 11) return cpf;
+    return cpfNormalizado.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  }
+
+  private carregarRelatorio(): void {
+    this.carregando.set(true);
+    this.mensagemErro.set('');
+
+    // Dispara as 3 requisições ao mesmo tempo
+    forkJoin({
+      clientes: this.http.get<any[]>('http://localhost:3000/clientes'),
+      contas: this.http.get<any[]>('http://localhost:3000/contas'),
+      gerentes: this.http.get<any[]>('http://localhost:3000/admin/gerentes')
+    })
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe({
+      next: (res) => {
+        // JOIN MANUAL exigido pela R16
+        const dadosMapeados = res.clientes.map(cliente => {
+          // Busca a conta que pertence a este cliente
+          const conta = res.contas.find(c => c.holderDocument === cliente.cpf);
+          
+          return {
+            cpfCliente: cliente.cpf,
+            nomeCliente: cliente.nome,
+            emailCliente: cliente.email,
+            salario: cliente.salario || 0,
+            numeroConta: conta ? conta.accountNumber : '-',
+            saldo: conta ? conta.availableBalance : 0,
+            limite: conta ? conta.limit : 0,
+            cpfGerente: conta && conta.managerDocument ? conta.managerDocument : '-',
+            nomeGerente: conta && conta.manager ? conta.manager : '-'
+          };
+        });
+
+        // Ordena a lista pelo nome do cliente em ordem alfabética
+        dadosMapeados.sort((a, b) => a.nomeCliente.localeCompare(b.nomeCliente));
+
+        this.fonteDados.data = dadosMapeados;
+        this.carregando.set(false);
+      },
+      error: () => {
+        this.mensagemErro.set('Não foi possível carregar os dados do relatório.');
+        this.carregando.set(false);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## 📝 Descrição
Implementação da tela de Relatório de Clientes (Issue R16). O desenvolvimento focou em trazer a lógica de negócio para o frontend, realizando um JOIN entre três bases de dados distintas.

**Principais alterações:**
- Criação do componente standalone `RelatorioClientesComponent`.
- Integração com o `mock-server.js` utilizando `forkJoin` do RxJS para consumir simultaneamente os endpoints `/clientes`, `/contas` e `/admin/gerentes`.
- Lógica de mapeamento e junção de dados cruzando o CPF do cliente com o `holderDocument` da conta bancária.
- Adição da rota `/relatorio-clientes` no arquivo `admin.routes.ts`.
- Ajuste e normalização da massa de dados nos mocks (`clientes.json`, `gerentes.json` e `conta-banco.json`) para viabilizar os testes da interface.

## 🛠 Tipo de Mudança
- ✨ **FEAT**: Nova funcionalidade.

## 🧪 Guia de Testes
**Como reproduzir:**
1. Certifique-se de que a massa de dados (`mock/*.json`) está atualizada com os arquivos enviados nesta PR.
2. Inicie o mock server rodando o comando `node mock-server.js` (rodando na porta 3000).
3. Inicie a aplicação Angular rodando o comando `ng serve`.
4. Acesse a aplicação e navegue até a rota `/admin/relatorio-clientes`.
5. Verifique se a Tela trouxe os dados corretos com clientes em ordem alfabética
**Resultado esperado:**
- A tela deve exibir a tabela contendo 9 colunas com os dados mesclados (Cliente + Conta + Gerente).
- A tabela deve renderizar inicialmente ordenada por ordem alfabética do "Nome do Cliente".
- O campo "Saldo" deve estar com a fonte verde (`text-highlight-green`) para valores positivos e vermelha (`text-highlight-red`) para valores negativos.
- Os campos monetários devem possuir formatação BRL (R$) e os campos de CPF devem estar com a máscara correta (`000.000.000-00`).

## 📸 Screenshots
<img width="1207" height="596" alt="image" src="https://github.com/user-attachments/assets/ed8b0b75-61ed-41ee-9432-2521663ff3e2" />
