### PR TITLE
[FRONTEND] [#49] Correção de divergência de saldo na tela de Saque (R6)

### DIFF
--- a/front-end/mock-server.js
+++ b/front-end/mock-server.js
@@ -583,6 +583,38 @@ app.get("/gerentes", (_req, res) => {
   res.json(gerentes);
 });
 
+app.post("/transacoes/saque", (req, res) => {
+  const { contaOrigem, valor } = req.body;
+  const contas = getData("contas");
+  let transacoes = getData("transacoes");
+
+  const idxOrigem = contas.findIndex(c => c.accountNumber === contaOrigem);
+
+  if (idxOrigem === -1) {
+    return res.status(404).json({ message: "Conta não encontrada." });
+  }
+  if (contas[idxOrigem].availableBalance + contas[idxOrigem].limit < valor) {
+      return res.status(400).json({ message: "Saldo insuficiente." });
+  }
+  contas[idxOrigem].availableBalance -= valor;
+  saveData("contas", contas);
+
+  const novaTransacao = {
+    id: Math.random().toString(36).substring(2, 10),
+    dataHora: new Date().toISOString(),
+    contaOrigem: contaOrigem,
+    tipo: "SAQUE",
+    valor: valor
+  };
+  transacoes.push(novaTransacao);
+  saveData("transacoes", transacoes);
+
+  res.json({ 
+    message: "Saque realizado com sucesso!",
+    novoSaldoOrigem: contas[idxOrigem].availableBalance
+  });
+});
+
 app.listen(PORT, () => {
   console.log(`Mock server rodando em http://localhost:${PORT}`);
 });

--- a/front-end/src/app/features/client/pages/saque-page/saque-page.component.html
+++ b/front-end/src/app/features/client/pages/saque-page/saque-page.component.html
@@ -1,50 +1,57 @@
 <main class="saque-wrapper">
-  <article class="saque-card">
-    <header class="saque-header">
-      <h1 class="saque-titulo heading_2">Saque</h1>
-      <p class="saque-subtitulo body_large">
-        Preencha o valor que deseja sacar da sua conta.
-      </p>
-    </header>
+  @if (account$ | async; as account) {
+    <article class="saque-card">
+      <header class="saque-header">
+        <h1 class="saque-titulo heading_2">Saque</h1>
+        <p class="saque-subtitulo body_large">
+          Preencha o valor que deseja sacar da sua conta.
+        </p>
+      </header>
 
-    <form class="saque-form" [formGroup]="saqueForm" (ngSubmit)="onEnviar()">
-      <div class="saque-campos">
-        <div class="campo-wrapper">
-          <label class="campo-label label_large" for="valor">*Valor</label>
-          <div class="campo-shell" [class.campo-shell--erro]="!!erroValor">
-            <span class="campo-prefix body_medium">R$</span>
-            <input
-              id="valor"
-              type="text"
-              class="body_medium"
-              inputmode="decimal"
-              autocomplete="off"
-              formControlName="valor"
-              placeholder="________________"
-              (keydown)="onValorKeydown($event)"
-              (input)="onValorInput($event)"
-              (paste)="onValorPaste($event)"
-            />
+      <form class="saque-form" [formGroup]="saqueForm" (ngSubmit)="onEnviar()">
+        <div class="saque-campos">
+          <div class="campo-wrapper">
+            <label class="campo-label label_large" for="valor">*Valor</label>
+            <div class="campo-shell" [class.campo-shell--erro]="!!erroValor">
+              <span class="campo-prefix body_medium">R$</span>
+              <input
+                id="valor"
+                type="text"
+                class="body_medium"
+                inputmode="decimal"
+                autocomplete="off"
+                formControlName="valor"
+                placeholder="________________"
+                (keydown)="onValorKeydown($event)"
+                (input)="onValorInput($event)"
+                (paste)="onValorPaste($event)"
+              />
+            </div>
+          </div>
+
+          <div class="campo-wrapper">
+            <label class="campo-label label_large" for="disponivel">Disponível</label>
+            <div id="disponivel" class="campo-shell campo-shell--readonly">
+              <span class="campo-readonly-valor body_medium">
+                  {{ formatCurrency(saldoDisponivel) }}              
+              </span>
+            </div>
           </div>
         </div>
 
-        <div class="campo-wrapper">
-          <label class="campo-label label_large" for="disponivel">Disponível</label>
-          <div id="disponivel" class="campo-shell campo-shell--readonly">
-            <span class="campo-readonly-valor body_medium">{{ saldoFormatado }}</span>
-          </div>
+        <p class="campo-obrigatorio body_medium" [class.campo-obrigatorio--erro]="!!erroValor">
+          {{ erroValor ?? '* Campo de preenchimento obrigatório' }}
+        </p>
+
+        <div class="saque-acoes">
+          <button 
+            type="submit" 
+            class="button-primary btn-enviar label_large" 
+            [disabled]="(saqueForm.invalid && saqueForm.touched) || isSubmitting">
+            Enviar
+          </button>
         </div>
-      </div>
-
-      <p class="campo-obrigatorio body_medium" [class.campo-obrigatorio--erro]="!!erroValor">
-        {{ erroValor ?? '* Campo de preenchimento obrigatório' }}
-      </p>
-
-      <div class="saque-acoes">
-        <button type="submit" class="button-primary btn-enviar label_large" [disabled]="saqueForm.invalid && saqueForm.touched">
-          Enviar
-        </button>
-      </div>
-    </form>
-  </article>
+      </form>
+    </article>
+  }
 </main>

--- a/front-end/src/app/features/client/pages/saque-page/saque-page.component.ts
+++ b/front-end/src/app/features/client/pages/saque-page/saque-page.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   AbstractControl,
   FormBuilder,
@@ -10,9 +12,11 @@ import {
 } from '@angular/forms';
 import { Router } from '@angular/router';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { finalize } from 'rxjs';
 
 import { SaqueConfirmacaoModalComponent } from '../../components/saque-confirmacao-modal/saque-confirmacao-modal.component';
-import { SaqueService } from '../../services/saque.service';
+import { ClientAccountService } from '../../services/client-account.service';
+import { formatCurrency } from '../../../../shared/utils/formatters';
 
 const valorPattern = /^\d+(?:[.,]\d{1,2})?$/;
 
@@ -41,26 +45,42 @@ const saqueValorValidator: ValidatorFn = (
 @Component({
   selector: 'app-saque-page',
   standalone: true,
-  imports: [ReactiveFormsModule, MatDialogModule],
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule],
   templateUrl: './saque-page.component.html',
   styleUrls: ['./saque-page.component.css'],
 })
 export class SaquePageComponent implements OnInit {
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly dialog = inject(MatDialog);
+  private readonly router = inject(Router);
+  private readonly clientAccountService = inject(ClientAccountService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly account$ = this.clientAccountService.getCurrentAccount();
+  readonly formatCurrency = formatCurrency;
+
   saqueForm!: FormGroup;
   saldoDisponivel = 0;
+  isSubmitting = false;
 
-  constructor(
-    private fb: FormBuilder,
-    private dialog: MatDialog,
-    private router: Router,
-    private saqueService: SaqueService
-  ) {}
-
-  get saldoFormatado(): string {
-    return this.saldoDisponivel.toLocaleString('pt-BR', {
-      style: 'currency',
-      currency: 'BRL',
+  ngOnInit(): void {
+    this.saqueForm = this.formBuilder.group({
+      valor: ['', [Validators.required, saqueValorValidator]],
     });
+
+    this.valorControl?.valueChanges.subscribe((valorAtual) => {
+      const valorSanitizado = this.sanitizarValor(String(valorAtual ?? ''));
+      if (valorAtual !== valorSanitizado) {
+        this.aplicarValorSanitizado(valorSanitizado);
+      }
+    });
+
+    this.account$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((account) => {
+        const limite = (account as any).limit ?? 5000;
+        this.saldoDisponivel = account.availableBalance + limite;
+      });
   }
 
   get valorControl() {
@@ -91,24 +111,6 @@ export class SaquePageComponent implements OnInit {
     }
 
     return null;
-  }
-
-  ngOnInit(): void {
-    this.saqueForm = this.fb.group({
-      valor: ['', [Validators.required, saqueValorValidator]],
-    });
-
-    this.valorControl?.valueChanges.subscribe((valorAtual) => {
-      const valorSanitizado = this.sanitizarValor(String(valorAtual ?? ''));
-
-      if (valorAtual !== valorSanitizado) {
-        this.aplicarValorSanitizado(valorSanitizado);
-      }
-    });
-
-    this.saqueService.getSaldoDisponivel().subscribe((conta) => {
-      this.saldoDisponivel = conta.saldo + conta.limite;
-    });
   }
 
   onValorInput(event: Event): void {
@@ -195,24 +197,24 @@ export class SaquePageComponent implements OnInit {
     });
 
     dialogRef.afterClosed().subscribe((confirmado: boolean) => {
-      if (!confirmado) {
-        return;
-      }
-
-      this.saqueService.realizarSaque(valorNumerico).subscribe({
-        next: () => {
-          this.router.navigate(['/cliente/saque/sucesso'], {
-            state: {
-              valor: valorNumerico,
-              dataHora: new Date().toISOString(),
-            },
-          });
-        },
-        error: (err: Error) => {
-          this.valorControl?.setErrors({ saldoInsuficiente: true });
-          console.error(err.message);
-        },
-      });
+      if (!confirmado) return;
+      this.isSubmitting = true;
+      this.clientAccountService.withdrawFromCurrentAccount({ amount: valorNumerico })
+        .pipe(finalize(() => this.isSubmitting = false))
+        .subscribe({
+          next: () => {
+            this.router.navigate(['/cliente/saque/sucesso'], {
+              state: {
+                valor: valorNumerico,
+                dataHora: new Date().toISOString(),
+              },
+            });
+          },
+          error: (err: Error) => {
+            this.valorControl?.setErrors({ saldoInsuficiente: true });
+            console.error(err.message);
+          },
+        });
     });
   }
 

--- a/front-end/src/app/features/client/pages/saque-page/saque-page.component.ts
+++ b/front-end/src/app/features/client/pages/saque-page/saque-page.component.ts
@@ -78,7 +78,7 @@ export class SaquePageComponent implements OnInit {
     this.account$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((account) => {
-        const limite = (account as any).limit ?? 5000;
+        const limite = (account as any).limit || 0;
         this.saldoDisponivel = account.availableBalance + limite;
       });
   }

--- a/front-end/src/app/features/client/services/client-account.service.ts
+++ b/front-end/src/app/features/client/services/client-account.service.ts
@@ -92,7 +92,7 @@ export class ClientAccountService {
 
       const transaction: AccountTransaction = {
         id: Math.random().toString(36).substring(2, 10),
-        type: 'withdrawal' as any,
+        type: 'withdrawal',
         amount: amount,
         description: request.description?.trim() || 'Saque em conta',
         performedAt: new Date().toISOString(),

--- a/front-end/src/app/features/client/services/client-account.service.ts
+++ b/front-end/src/app/features/client/services/client-account.service.ts
@@ -67,6 +67,57 @@ export class ClientAccountService {
     }
   }
 
+  withdrawFromCurrentAccount(request: { amount: number; description?: string }): Observable<BankAccount> {
+    const currentUser = this.authService.currentUserValue;
+
+    if (currentUser && currentUser.tipo !== 'cliente') {
+      return throwError(
+        () => new Error('Apenas clientes podem realizar saques.')
+      );
+    }
+
+    try {
+      const amount = this.validateAmount(request.amount);
+      const currentAccount = this.accountStateSubject.value;
+      const limit = (currentAccount as any).limit || 0;
+      const availableToWithdraw = currentAccount.availableBalance + limit;
+
+      if (amount > availableToWithdraw) {
+        return throwError(() => new Error('Saldo insuficiente para este saque.'));
+      }
+
+      const balanceAfter = this.roundCurrency(
+        currentAccount.availableBalance - amount
+      );
+
+      const transaction: AccountTransaction = {
+        id: Math.random().toString(36).substring(2, 10),
+        type: 'withdrawal' as any,
+        amount: amount,
+        description: request.description?.trim() || 'Saque em conta',
+        performedAt: new Date().toISOString(),
+        balanceAfter: balanceAfter
+      } as AccountTransaction;
+
+      const updatedAccount: BankAccount = {
+        ...currentAccount,
+        availableBalance: balanceAfter,
+        transactions: [transaction, ...currentAccount.transactions],
+      };
+
+      this.persistAccountState(updatedAccount);
+      this.accountStateSubject.next(updatedAccount);
+
+      return of(updatedAccount);
+    } catch (error) {
+      return throwError(() =>
+        error instanceof Error
+          ? error
+          : new Error('Nao foi possivel processar o saque.')
+      );
+    }
+  }
+
   private loadAccountState(): BankAccount {
     const storageKey = this.buildStorageKey();
     const persistedState = localStorage.getItem(storageKey);
@@ -172,7 +223,7 @@ export class ClientAccountService {
 
     return (
       typeof transaction.id === 'string' &&
-      transaction.type === 'deposit' &&
+      (transaction.type === 'deposit' || transaction.type === 'withdrawal') &&
       typeof transaction.amount === 'number' &&
       typeof transaction.description === 'string' &&
       typeof transaction.performedAt === 'string' &&

--- a/front-end/src/app/shared/models/account-transaction.ts
+++ b/front-end/src/app/shared/models/account-transaction.ts
@@ -1,4 +1,4 @@
-export type AccountTransactionType = 'deposit';
+export type AccountTransactionType = 'deposit' | 'withdrawal';
 
 export interface AccountTransaction {
   id: string;


### PR DESCRIPTION
### Título do PR
[FRONTEND] [#49] Correção de divergência de saldo na tela de Saque (R6)

### Corpo do PR
## 📝 Descrição
Foi corrigido o bug identificado durante a homologação da issue #49, onde a tela de saque exibia um saldo divergente em relação à página inicial e não atualizava após a operação

As seguintes alterações foram feitas (restritas ao escopo da R6):
- Substituição do `SaqueService` pelo `ClientAccountService` no componente `SaquePageComponent`, padronizando a aplicação
- Criação do método `withdrawFromCurrentAccount` no `ClientAccountService` para processar o saque, atualizar o `BehaviorSubject` localmente e refletir as mudanças em tempo real na Home.
- Atualização do validador `isAccountTransaction` para reconhecer eventos do tipo `'withdrawal'`, impedindo a limpeza acidental do histórico local.

## 🛠 Tipo de Mudança
- 🐛 **FIX**: Correção de bug.

## 🧪 Guia de Testes
**Como reproduzir:**
1. Rodar o comando `ng serve`.
2. Rodar o comando `node mock-server.js`.
3. Fazer login na aplicação com um usuário do tipo cliente.
4. Acessar a Home e observar o saldo atual exibido na tela.
5. Navegar para a tela de Saque (`/cliente/saque`).
6. Preencher um valor no campo de saque e confirmar a operação.
7. Após o redirecionamento/sucesso, voltar para a Home e verificar se o saldo foi atualizado corretamente.

**Resultado esperado:**
- A tela de saque deve exibir o mesmo saldo do estado global. Após efetivar o saque, a dedução do valor deve ser refletida instantaneamente nos outros pontos do fluxo sem divergências.

## 📸 Screenshots
antes do saque 
<img width="1252" height="577" alt="Captura de tela 2026-04-05 161318" src="https://github.com/user-attachments/assets/1ba32a9c-bae4-457b-88de-886f1b70fb9c" />

pós saque 
<img width="1288" height="574" alt="Captura de tela 2026-04-05 161342" src="https://github.com/user-attachments/assets/1e160a6a-6a1f-442d-83c4-55c819046326" />


