### PR TITLE
[BACKEND] ajuste para aparecer nome tambem no login e logout

### DIFF
--- a/back-end/auth/pom.xml
+++ b/back-end/auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>3.4.0</version>
         <relativePath/> </parent>
     <groupId>com.bantads</groupId>
     <artifactId>auth</artifactId>

--- a/back-end/auth/src/main/java/com/bantads/auth/AuthApplication.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/AuthApplication.java
@@ -1,13 +1,14 @@
 package com.bantads.auth;
 
-import com.bantads.auth.model.User;
-import com.bantads.auth.model.TipoUsuario;
-import com.bantads.auth.repository.UserRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.bantads.auth.model.TipoUsuario;
+import com.bantads.auth.model.User;
+import com.bantads.auth.repository.UserRepository;
 
 @SpringBootApplication
 public class AuthApplication {
@@ -25,6 +26,7 @@ public class AuthApplication {
                 testUser.setEmail("admin@bantads.com");
                 testUser.setSenha(passwordEncoder.encode("123456"));
                 testUser.setTipo(TipoUsuario.ADMIN);
+                testUser.setNome("Anna");
                 testUser.setReferenciaId("12345678900");
 
                 userRepository.save(testUser);

--- a/back-end/auth/src/main/java/com/bantads/auth/controller/AuthController.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/controller/AuthController.java
@@ -1,18 +1,22 @@
 package com.bantads.auth.controller;
-
-import com.bantads.auth.dto.LoginResponseDTO;
-import com.bantads.auth.dto.LoginRequestDTO;
-import com.bantads.auth.dto.LogoutResponseDTO;
-import com.bantads.auth.model.User;
-import com.bantads.auth.repository.UserRepository;
-import com.bantads.auth.service.LoginService;
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bantads.auth.dto.LoginRequestDTO;
+import com.bantads.auth.dto.LoginResponseDTO;
+import com.bantads.auth.dto.LogoutResponseDTO;
+import com.bantads.auth.model.User;
+import com.bantads.auth.repository.UserRepository;
+import com.bantads.auth.service.LoginService;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping
@@ -44,10 +48,9 @@ public class AuthController {
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
 
-        // Retornamos null no nome pelo mesmo motivo da modelagem enxuta
         LogoutResponseDTO response = new LogoutResponseDTO(
                 user.getReferenciaId(),
-                null, 
+                user.getNome(),
                 user.getEmail(),
                 user.getTipo().name()
         );

--- a/back-end/auth/src/main/java/com/bantads/auth/model/User.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/model/User.java
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
@@ -22,16 +23,18 @@ public class User {
     private String senha; 
 
     private TipoUsuario tipo; 
+    private String nome;
 
     @Field("referencia_id")
-    private String referenciaId; // Guarda o CPF do Cliente/Gerente ou ID do Admin
+    private String referenciaId;
 
     public User() {}
 
-    public User(String email, String senha, TipoUsuario tipo, String referenciaId) {
+    public User(String email, String senha, TipoUsuario tipo, String referenciaId, String nome) {
         this.email = email;
         this.senha = senha;
         this.tipo = tipo;
+        this.nome = nome;
         this.referenciaId = referenciaId;
     }
 
@@ -46,6 +49,9 @@ public class User {
     
     public TipoUsuario getTipo() { return tipo; }
     public void setTipo(TipoUsuario tipo) { this.tipo = tipo; }
+    
+    public String getNome() { return nome; }
+    public void setNome(String nome) { this.nome = nome; }
     
     public String getReferenciaId() { return referenciaId; }
     public void setReferenciaId(String referenciaId) { this.referenciaId = referenciaId; }

--- a/back-end/auth/src/main/java/com/bantads/auth/security/JwtAuthenticationFilter.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/security/JwtAuthenticationFilter.java
@@ -1,10 +1,9 @@
 package com.bantads.auth.security;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,9 +12,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -45,10 +47,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String email = jwt.getSubject();
             String cpf = jwt.getClaim("cpf").asString();   
             String tipo = jwt.getClaim("tipo").asString(); 
+            String nome = jwt.getClaim("nome").asString(); 
 
             List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(tipo));
 
-            UserPrincipal principal = new UserPrincipal(cpf, email, tipo);
+            UserPrincipal principal = new UserPrincipal(cpf, email, tipo, nome);
 
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                     principal,

--- a/back-end/auth/src/main/java/com/bantads/auth/security/SecurityConfig.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/security/SecurityConfig.java
@@ -37,7 +37,6 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable()) 
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                // Rotas de Autenticação liberadas explicitamente conforme o Swagger
                 .requestMatchers("/login", "/Logout", "/api/auth/**").permitAll()
                 .requestMatchers("/error").permitAll()
                 .anyRequest().authenticated()

--- a/back-end/auth/src/main/java/com/bantads/auth/security/UserPrincipal.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/security/UserPrincipal.java
@@ -1,22 +1,24 @@
 package com.bantads.auth.security; 
-
-import com.bantads.auth.model.User;
+import java.util.Collection;
+import java.util.Collections;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import java.util.Collection;
-import java.util.Collections;
+
+import com.bantads.auth.model.User;
 
 public class UserPrincipal implements UserDetails {
 
     private String referenciaId;
     private String email;
+    private String nome;
     private String password;
     private Collection<? extends GrantedAuthority> authorities;
 
     public UserPrincipal(User user) {
         this.referenciaId = user.getReferenciaId();
         this.email = user.getEmail();
+        this.nome = user.getNome();
         this.password = user.getSenha(); 
         
         this.authorities = Collections.singletonList(
@@ -24,9 +26,10 @@ public class UserPrincipal implements UserDetails {
         );
     }
 
-    public UserPrincipal(String referenciaId, String email, String tipo) {
+    public UserPrincipal(String referenciaId, String email, String tipo, String nome) {
         this.referenciaId = referenciaId;
         this.email = email;
+        this.nome = nome;
         this.password = null; 
         
         this.authorities = Collections.singletonList(
@@ -35,6 +38,7 @@ public class UserPrincipal implements UserDetails {
     }
 
     public String getReferenciaId() { return referenciaId; }
+    public String getNome() { return nome; }
     @Override public String getUsername() { return email; }
     @Override public String getPassword() { return password; }
     @Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }

--- a/back-end/auth/src/main/java/com/bantads/auth/service/LoginServiceImpl.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/service/LoginServiceImpl.java
@@ -1,11 +1,5 @@
 package com.bantads.auth.service;
 
-import com.bantads.auth.dto.LoginResponseDTO;
-import com.bantads.auth.dto.LoginRequestDTO;
-import com.bantads.auth.dto.UsuarioDTO;
-import com.bantads.auth.model.User;
-import com.bantads.auth.repository.UserRepository;
-import com.bantads.auth.security.TokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,6 +7,13 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import com.bantads.auth.dto.LoginRequestDTO;
+import com.bantads.auth.dto.LoginResponseDTO;
+import com.bantads.auth.dto.UsuarioDTO;
+import com.bantads.auth.model.User;
+import com.bantads.auth.repository.UserRepository;
+import com.bantads.auth.security.TokenService;
 
 @Service
 public class LoginServiceImpl implements LoginService {
@@ -42,8 +43,8 @@ public class LoginServiceImpl implements LoginService {
 
         String token = tokenService.generateToken(user);
         
-        // Nome passado como nulo, pois a tabela de Auth não possui mais essa coluna
-        UsuarioDTO usuarioInfo = new UsuarioDTO(null, user.getReferenciaId(), user.getEmail());
+        
+        UsuarioDTO usuarioInfo = new UsuarioDTO(user.getNome(), user.getReferenciaId(), user.getEmail());
 
         return new LoginResponseDTO(token, user.getTipo().name(), usuarioInfo);
     }


### PR DESCRIPTION
## 📝 Descrição
Criação e finalização do microsserviço de Autenticação (ms-auth), estruturado para validar credenciais, gerar Tokens JWT e validar o acesso

A diferença do teste dos prints para o novo teste é que no novo aparece também o nome.

## 🛠 Tipo de Mudança
- ✨ **FEAT**: Nova funcionalidade.

## 🧪 Guia de Testes
**Como reproduzir:**
1. Esteja na raíz do projeto `back-end/auth`
2. Rode comando `./mvnw spring-boot:run`
3. Abra o Insomnia (ou Postman) e faça uma requisição `POST` para `http://localhost:8080/login`
4. Selecione JSON como Body e envie a requisição: 
{
  "login": "admin@bantads.com",
  "senha": "123456"
}
5. Copie o acess token gerado
6. Crie uma nova requisição POST para a rota protegida `http://localhost:8080/Logout`
7. Vá na aba "Auth" (Insomnia) ou "Authorization" (Postman), selecione "Bearer Token", cole o token copiado e envie a requisição.

**Resultado esperado:**
- No /login: O comportamento deve ser o retorno do Status 200 OK trazendo o token JWT assinado, o tipo do token (bearer), o tipo do usuário e seus dados básicos omitindo a senha, exatamente conforme contrato do Swagger.

- No /Logout: O comportamento deve ser o retorno do Status 200 OK, provando que o JwtAuthenticationFilter conseguiu ler, validar a assinatura e decodificar as claims do token com sucesso, retornando os dados do usuário deslogado.

## 📸 Screenshots
<img width="1832" height="484" alt="image" src="https://github.com/user-attachments/assets/0453a64e-9616-4357-9bcd-107ee354b29a" />

<img width="1293" height="467" alt="Captura de tela 2026-04-14 201814" src="https://github.com/user-attachments/assets/b3394318-5325-42a3-8338-08b3e3def309" />
