### PR TITLE
Fix consulta de clientes e ajuste no autocadastro

### DIFF
--- a/front-end/src/app/core/auth/pages/signup-page/signup-page.component.css
+++ b/front-end/src/app/core/auth/pages/signup-page/signup-page.component.css
@@ -1,8 +1,11 @@
 main {
   display: flex;
-  padding: 8px 0 8px 8px;
-  padding-right: 0;
-  background-color: #fafafa;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  background-color: var(--color-card, #FAFAFA);
 }
 
 section {
@@ -13,12 +16,16 @@ section {
 }
 
 .illustration-section {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
   width: 60%;
-  border-radius: var(--radius-lg, 24px);
-  background: var(--color-green-900, #08462e);
-  padding: 0 var(--spacing-3xl, 64px);
+  height: 100%;
+  border-radius: 0 var(--radius-lg, 24px) var(--radius-lg, 24px) 0;
+  background: var(--color-green-900, #08462E);
+  padding: var(--spacing-3xl, 64px);
   gap: 16px;
-  padding-top: 16px;
+  box-sizing: border-box;
 }
 
 .title-login {
@@ -32,7 +39,9 @@ section {
 
 .container-illustration {
   display: flex;
+  flex: 1;
   justify-content: center;
+  align-items: center;
   width: 100%;
 }
 
@@ -58,6 +67,20 @@ section {
   gap: var(--spacing-xl, 40px);
   flex-shrink: 0;
   background: var(--color-card, #fafafa);
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  width: 40%;
+  height: 100%;
+  padding: var(--spacing-lg, 32px) var(--spacing-xl, 40px);
+  gap: var(--spacing-xl, 40px);
+  box-sizing: border-box;
+  background: var(--color-card, #FAFAFA);
+  overflow-y: auto;
 }
 
 .form-text {
@@ -162,4 +185,14 @@ section {
   .registration-container {
     width: 100%;
   }
+}
+
+mat-stepper {
+  width: 100%;
+  background: transparent;
+}
+
+@media (max-width: 720px) {
+  .illustration-section { display: none; }
+  .form-section { width: 100%; align-items: center; }
 }

--- a/front-end/src/app/core/auth/pages/signup-page/signup-page.component.html
+++ b/front-end/src/app/core/auth/pages/signup-page/signup-page.component.html
@@ -23,7 +23,7 @@
       <app-successful-signup></app-successful-signup>
     </section>
   } @else {
-  <section class="registration-container">
+  <section class="form-section">
     <div class="form-text">
       <h3 class="heading_3">Crie sua conta</h3>
       <p class="body_medium">Preencha suas informações para criar um conta.</p>
@@ -89,7 +89,7 @@
             </div>
 
             <div class="first-button w-full">
-              <button class="button-primary label_large w-full" matStepperNext>
+              <button class="button-primary label_large w-full" type="button" (click)="proximoPasso(stepper)">
                 Próximo
               </button>
             </div>
@@ -184,8 +184,8 @@
                 Voltar
               </button>
               <button
-                class="button-primary label_large"
-                matStepperNext
+              class="button-primary label_large"
+                type="submit"
                 (click)="onSubmit()"
               >
                 Registrar

--- a/front-end/src/app/core/auth/pages/signup-page/signup-page.component.ts
+++ b/front-end/src/app/core/auth/pages/signup-page/signup-page.component.ts
@@ -151,4 +151,12 @@ export class SignupPageComponent {
     if (control?.hasError('required')) return 'O CPF é obrigatório';
     return 'CPF inválido';
   }
+
+  proximoPasso(stepper: any) {
+    if (this.firstFormGroup.valid) {
+      stepper.next();
+    } else {
+      this.firstFormGroup.markAllAsTouched();
+    }
+  }
 }

--- a/front-end/src/app/features/manager/pages/013-consultar-cliente/013-consultar-cliente.component.html
+++ b/front-end/src/app/features/manager/pages/013-consultar-cliente/013-consultar-cliente.component.html
@@ -9,11 +9,11 @@
           <input
             type="text"
             [(ngModel)]="cpfPesquisa"
-            (keyup)="apenasNumeros()"
+            (ngModelChange)="aplicarMascaraCpf($event)"
             (keyup.enter)="pesquisarCliente()"
             placeholder="Digite o CPF..."
             class="search-input"
-            maxlength="11"
+            maxlength="14"
           />
           <button class="search-btn" (click)="pesquisarCliente()" [disabled]="carregando || !validarCpf(cpfPesquisa)">
             {{ carregando ? 'Buscando...' : 'Buscar' }}

--- a/front-end/src/app/features/manager/pages/013-consultar-cliente/013-consultar-cliente.component.ts
+++ b/front-end/src/app/features/manager/pages/013-consultar-cliente/013-consultar-cliente.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { DetalheClienteService, ClienteDetalhado } from '../../services/detalhe-cliente.service';
 import { formatCpf, formatPhone, formatCep } from '../../../../shared/utils/formatters';
+import { AuthService } from '../../../../core/auth/services/auth.service';
 
 @Component({
   selector: 'app-consultar-cliente',
@@ -15,6 +16,7 @@ import { formatCpf, formatPhone, formatCep } from '../../../../shared/utils/form
 export class ConsultarClienteComponent implements OnInit {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly detalheClienteService = inject(DetalheClienteService);
+  private readonly authService = inject(AuthService);
 
   cpfPesquisa: string = '';
   clienteAtual: ClienteDetalhado | null = null;
@@ -32,13 +34,13 @@ export class ConsultarClienteComponent implements OnInit {
       const cpfDaUrl = params.get('cpf');
       if (cpfDaUrl) {
         this.cpfPesquisa = cpfDaUrl;
-        this.pesquisarCliente(); // ✅ sem setTimeout
+        this.pesquisarCliente();
       }
     });
   }
 
-  apenasNumeros(): void {
-    this.cpfPesquisa = this.cpfPesquisa.replace(/\D/g, '');
+  aplicarMascaraCpf(valor: string): void {
+    this.cpfPesquisa = this.formatCpf(valor);
   }
 
   validarCpf(cpf: string): boolean {
@@ -75,6 +77,18 @@ export class ConsultarClienteComponent implements OnInit {
     this.detalheClienteService.obterClienteDetalhadoPorCpf(cpfLimpo).subscribe({
       next: (cliente) => {
         if (cliente) {
+          const gerenteLogado = this.authService.currentUserValue;
+          const cpfGerenteLogado = gerenteLogado?.cpf ? gerenteLogado.cpf.replace(/\D/g, '') : '';
+          const docGerenteConta = cliente.managerDocument ? String(cliente.managerDocument) : '';
+          const managerCpfLimpo = docGerenteConta.replace(/\D/g, '');
+
+          if (managerCpfLimpo && managerCpfLimpo !== cpfGerenteLogado) {
+            this.clienteAtual = null;
+            this.erro = 'Acesso Negado: Este cliente pertence a outro gerente.';
+            this.carregando = false;
+            return;
+          }
+          
           this.clienteAtual = cliente;
           this.erro = '';
         } else {

--- a/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.ts
+++ b/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { forkJoin } from 'rxjs';
 import { AuthService } from '../../../../core/auth/services/auth.service';
+import { formatCpf } from '../../../../shared/utils/formatters';
 
 export interface Cliente {
   id: string;
@@ -161,13 +162,7 @@ export class ConsultarClientesComponent implements OnInit {
     let valor = input.value;
 
     if (this.tipoFiltro === 'cpf') {
-      valor = valor.replace(/\D/g, ''); // Remove tudo que não for número
-
-      if (valor.length > 11) valor = valor.slice(0, 11);
-      if (valor.length > 9) valor = valor.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
-      else if (valor.length > 6) valor = valor.replace(/(\d{3})(\d{3})(\d{1,3})/, '$1.$2.$3');
-      else if (valor.length > 3) valor = valor.replace(/(\d{3})(\d{1,3})/, '$1.$2');
-      
+      valor = formatCpf(valor); // Olha que código elegante e limpo!
     } else if (this.tipoFiltro === 'nome') {
       valor = valor.replace(/\d/g, ''); 
     }

--- a/front-end/src/app/features/manager/services/detalhe-cliente.service.ts
+++ b/front-end/src/app/features/manager/services/detalhe-cliente.service.ts
@@ -38,6 +38,7 @@ export interface ClienteDetalhado {
   salario: string;
   saldo: string;
   limite: string;
+  managerDocument?: string;
 }
 
 @Injectable({
@@ -72,6 +73,7 @@ export class DetalheClienteService {
           salario: this.formatarMoeda(cliente.salario),
           saldo: this.formatarMoeda(conta?.availableBalance || 0),
           limite: this.formatarMoeda(conta?.limit || 0),
+          managerDocument: (conta as any)?.managerDocument || (conta as any)?.manager
         };
       }),
     );

--- a/front-end/src/app/shared/utils/formatters.ts
+++ b/front-end/src/app/shared/utils/formatters.ts
@@ -2,14 +2,17 @@
 export function formatCpf(cpf: string): string {
   if (!cpf) return '';
 
-  const digits = cpf.replace(/\D/g, '');
+  let digits = cpf.replace(/\D/g, '').slice(0, 11);
 
-  if (digits.length !== 11) return cpf;
+  if (digits.length > 9) {
+    return digits.replace(/(\d{3})(\d{3})(\d{3})(\d{1,2})/, '$1.$2.$3-$4');
+  } else if (digits.length > 6) {
+    return digits.replace(/(\d{3})(\d{3})(\d{1,3})/, '$1.$2.$3');
+  } else if (digits.length > 3) {
+    return digits.replace(/(\d{3})(\d{1,3})/, '$1.$2');
+  }
 
-  return digits.replace(
-    /(\d{3})(\d{3})(\d{3})(\d{2})/,
-    '$1.$2.$3-$4'
-  );
+  return digits;
 }
 
 // ================= CEP =================


### PR DESCRIPTION
📝 Descrição
Feito ajuste da listagem da consulta de cliente individual pelo gerente e na tela de autocadastro. 

O que foi feito:

Nos requisitos era implícito que o gerente só pode pesquisar clientes seus, essa regra é atendida na listagem de clientes e na consulta individual não era. Agora é, fi. 
Além disso foi ajustado as máscaras de CPF em ambas as telas mencionadas acima e foram feitas leves alterações no autocadastro, agora ao tentar ir pro próximo passo os campos necessários são destacados e o layout está igual ao de login.

🛠 Tipo de Mudança
✨ Fix: Nova funcionalidade.

##🧪 Guia de Testes
Como reproduzir:

1- Rodar ng serve
2 - Rodar o mock-server
3 - Acessar a tela de autocadastro e visualizar que está no mesmo formato que a de login
4 - Tentar ir pro próximo passo sem preencher os campos -> Deverá mostrar os campos vazios com aviso vermelhinho embaixo
5 - Loggar como gerente (Ex: ger3@bantads.com.br)
6 - Visualizar no arquivo auth.json quais clientes pertencem ao gerente, (Ex: CPF 12912861012 pertence ao ger3) deve ser possível pesquisar esse cliente em http://localhost:4200/gerente/consultar-cliente
7 - Tentar pesquisar um cliente que não pertence ao gerente (Ex: CPF 85733854057 não pertence ao ger3), deve exibir mensagem de erro
8 - Verificar que ao ter digitado os CPFs a máscara de CPF é aplicada

##📸 Screenshots
<img width="1917" height="984" alt="image" src="https://github.com/user-attachments/assets/bb1d0a9c-104d-4fb4-9437-c8f673832c38" />
(Cliente pertence ao gerente)

<img width="1916" height="981" alt="image" src="https://github.com/user-attachments/assets/d0b6aebb-f3a9-48a9-a2a3-82e9207a75ec" />
(Cliente não pertence ao gerente)

<img width="1916" height="987" alt="image" src="https://github.com/user-attachments/assets/e3e73c76-128f-4ce1-9149-e9139b8f5e55" />
(Tentativa de prosseguir sem preencher os dados)
