### PR TITLE
[FRONTEND] 001 - Corrige tipos do extrato

### DIFF
--- a/front-end/src/app/features/client/pages/008-consulta-de-extrato/008-consulta-de-extrato.utils.spec.ts
+++ b/front-end/src/app/features/client/pages/008-consulta-de-extrato/008-consulta-de-extrato.utils.spec.ts
@@ -1,7 +1,102 @@
-import { criarGruposTransacoes } from './008-consulta-de-extrato.utils';
+import {
+  criarGruposTransacoes,
+  mapearMovimentacoesDoExtrato,
+} from './008-consulta-de-extrato.utils';
 import { ExtratoTransaction } from './extrato-transaction.model';
 
 describe('008-consulta-de-extrato.utils', () => {
+  describe('mapearMovimentacoesDoExtrato', () => {
+    it('deve reconhecer tipos em caixa alta e sem acento', () => {
+      const transacoes = mapearMovimentacoesDoExtrato(
+        [
+          {
+            data: '2026-04-07T10:00:00-03:00',
+            tipo: 'DEPOSITO',
+            origem: null,
+            destino: '1291',
+            valor: 100,
+          },
+          {
+            data: '2026-04-07T11:00:00-03:00',
+            tipo: 'SAQUE',
+            origem: '1291',
+            destino: null,
+            valor: 50,
+          },
+          {
+            data: '2026-04-07T12:00:00-03:00',
+            tipo: 'TRANSFERENCIA',
+            origem: '1291',
+            destino: '0950',
+            valor: 25,
+          },
+        ],
+        '1291',
+      );
+
+      expect(transacoes.map((transacao) => transacao.operacao)).toEqual([
+        'Depósito',
+        'Saque',
+        'Transferência',
+      ]);
+    });
+
+    it('deve mapear rotulos, categorias e sinais das movimentacoes', () => {
+      const transacoes = mapearMovimentacoesDoExtrato(
+        [
+          {
+            data: '2026-04-07T10:00:00-03:00',
+            tipo: 'DEPOSITO',
+            origem: null,
+            destino: '1291',
+            valor: 100,
+          },
+          {
+            data: '2026-04-07T11:00:00-03:00',
+            tipo: 'SAQUE',
+            origem: '1291',
+            destino: null,
+            valor: 50,
+          },
+          {
+            data: '2026-04-07T12:00:00-03:00',
+            tipo: 'TRANSFERENCIA',
+            origem: '1291',
+            destino: '0950',
+            valor: 25,
+          },
+          {
+            data: '2026-04-07T13:00:00-03:00',
+            tipo: 'TRANSFERENCIA',
+            origem: '0950',
+            destino: '1291',
+            valor: 75,
+          },
+        ],
+        '1291',
+      );
+
+      expect(transacoes.map((transacao) => transacao.operacao)).toEqual([
+        'Depósito',
+        'Saque',
+        'Transferência',
+        'Transferência',
+      ]);
+      expect(transacoes.map((transacao) => transacao.categoria)).toEqual([
+        'Operação bancária',
+        'Operação bancária',
+        'Transferência',
+        'Transferência',
+      ]);
+      expect(transacoes.map((transacao) => transacao.operacaoColor)).toEqual([
+        'blue',
+        'red',
+        'red',
+        'blue',
+      ]);
+    });
+  });
+
   it('deve incluir transacoes do mesmo dia mesmo com horario no filtro', () => {
     const transacoes: ExtratoTransaction[] = [
       {

--- a/front-end/src/app/features/client/pages/008-consulta-de-extrato/008-consulta-de-extrato.utils.ts
+++ b/front-end/src/app/features/client/pages/008-consulta-de-extrato/008-consulta-de-extrato.utils.ts
@@ -15,6 +15,8 @@ export interface MovimentacaoExtratoApi {
   valor: number;
 }
 
+type TipoMovimentacao = 'deposito' | 'saque' | 'transferencia';
+
 interface FiltroPersistidoExtrato {
   dataInicio: string;
   dataFim: string;
@@ -32,24 +34,26 @@ export function mapearMovimentacoesDoExtrato(
   numeroConta: string,
 ): ExtratoTransaction[] {
   return movimentacoes.map((movimentacao) => {
+    const tipoMovimentacao = normalizarTipoMovimentacao(movimentacao.tipo);
     const transferenciaRecebida =
-      movimentacao.tipo === 'transferência' &&
+      tipoMovimentacao === 'transferencia' &&
       movimentacao.destino === numeroConta &&
       movimentacao.origem !== numeroConta;
 
     return {
       data: formatarDataParaInput(new Date(movimentacao.data)),
       hora: extrairHoraDaDataIso(movimentacao.data),
-      operacao: mapearTipoOperacao(movimentacao.tipo),
+      operacao: mapearTipoOperacao(tipoMovimentacao),
       remetenteDestinatario: mapearRemetenteDestinatario(
         movimentacao,
         numeroConta,
+        tipoMovimentacao,
       ),
-      categoria: mapearCategoria(movimentacao.tipo),
+      categoria: mapearCategoria(tipoMovimentacao),
       valor: formatCurrency(Math.abs(movimentacao.valor)),
       operacaoColor:
-        movimentacao.tipo === 'saque' ||
-        (movimentacao.tipo === 'transferência' && !transferenciaRecebida)
+        tipoMovimentacao === 'saque' ||
+        (tipoMovimentacao === 'transferencia' && !transferenciaRecebida)
           ? 'red'
           : 'blue',
     };
@@ -146,6 +150,24 @@ export function calcularImpactoDasTransacoes(
   }, 0);
 }
 
+function normalizarTipoMovimentacao(tipo: string): TipoMovimentacao {
+  const tipoNormalizado = tipo
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+
+  if (tipoNormalizado === 'deposito') {
+    return 'deposito';
+  }
+
+  if (tipoNormalizado === 'saque') {
+    return 'saque';
+  }
+
+  return 'transferencia';
+}
+
 function extrairHoraDaDataIso(dataIso: string): string {
   const data = new Date(dataIso);
   const horas = String(data.getHours()).padStart(2, '0');
@@ -153,8 +175,8 @@ function extrairHoraDaDataIso(dataIso: string): string {
   return `${horas}:${minutos}`;
 }
 
-function mapearTipoOperacao(tipo: string): string {
-  if (tipo === 'depósito') {
+function mapearTipoOperacao(tipo: TipoMovimentacao): string {
+  if (tipo === 'deposito') {
     return 'Depósito';
   }
 
@@ -168,8 +190,9 @@ function mapearTipoOperacao(tipo: string): string {
 function mapearRemetenteDestinatario(
   movimentacao: MovimentacaoExtratoApi,
   numeroConta: string,
+  tipoMovimentacao: TipoMovimentacao,
 ): string {
-  if (movimentacao.tipo === 'depósito' || movimentacao.tipo === 'saque') {
+  if (tipoMovimentacao === 'deposito' || tipoMovimentacao === 'saque') {
     return 'Você';
   }
 
@@ -188,8 +211,8 @@ function mapearRemetenteDestinatario(
   return 'Você';
 }
 
-function mapearCategoria(tipo: string): string {
-  if (tipo === 'transferência') {
+function mapearCategoria(tipo: TipoMovimentacao): string {
+  if (tipo === 'transferencia') {
     return 'Transferência';
   }
 

--- a/front-end/src/app/features/client/pages/deposit-page.component.spec.ts
+++ b/front-end/src/app/features/client/pages/deposit-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { of } from 'rxjs';
 
 import { BankAccount } from '../../../shared/models/bank-account';
@@ -29,7 +30,7 @@ class ClientAccountServiceStub {
           id: 'deposit-1',
           type: 'deposit' as const,
           amount: 100,
-          description: 'Depósito em conta',
+          description: 'Deposito em conta',
           performedAt: '2026-03-07T12:00:00.000Z',
           balanceAfter: 2550.75,
         },
@@ -48,6 +49,12 @@ describe('DepositPageComponent', () => {
       imports: [DepositPageComponent],
       providers: [
         { provide: ClientAccountService, useClass: ClientAccountServiceStub },
+        {
+          provide: Router,
+          useValue: {
+            navigate: jasmine.createSpy('navigate'),
+          },
+        },
       ],
     }).compileComponents();
 
@@ -60,13 +67,10 @@ describe('DepositPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should sanitize amount input to digits and a single decimal separator', () => {
-    const input = document.createElement('input');
-    input.value = '12a.3,4b5';
+  it('should accept a valid monetary amount before confirmation', () => {
+    component.depositForm.controls.amount.setValue('12,34');
 
-    component.onAmountInput({ target: input } as unknown as Event);
-
-    expect(input.value).toBe('12,34');
     expect(component.depositForm.controls.amount.value).toBe('12,34');
+    expect(component.depositForm.valid).toBeTrue();
   });
 });

--- a/front-end/src/app/features/client/pages/saque-page/saque-page.component.spec.ts
+++ b/front-end/src/app/features/client/pages/saque-page/saque-page.component.spec.ts
@@ -1,14 +1,18 @@
-import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
 
+import { AuthService } from '../../../../core/auth/services/auth.service';
 import { ClientAccountService } from '../../services/client-account.service';
 import { SaquePageComponent } from './saque-page.component';
 
 describe('SaquePageComponent', () => {
   let component: SaquePageComponent;
   let fixture: ComponentFixture<SaquePageComponent>;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -24,6 +28,14 @@ describe('SaquePageComponent', () => {
           provide: Router,
           useValue: {
             navigate: jasmine.createSpy('navigate'),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            currentUserValue: {
+              cpf: '12345678910',
+            },
           },
         },
         {
@@ -46,71 +58,41 @@ describe('SaquePageComponent', () => {
               .and.returnValue(of(null)),
           },
         },
+        provideHttpClient(),
+        provideHttpClientTesting(),
       ],
     }).compileComponents();
 
+    httpTestingController = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(SaquePageComponent);
     component = fixture.componentInstance;
+    httpTestingController.expectOne('http://localhost:3000/contas/cpf/12345678910').flush({
+      numeroConta: '123456-7',
+      saldoDisponivel: 125.49,
+      limite: 5000,
+    });
     fixture.detectChanges();
   });
 
-  it('deve sanitizar caracteres inválidos no input de valor', fakeAsync(() => {
-    const input = document.createElement('input');
-    input.value = 'abc12,3x';
-
-    component.onValorInput({ target: input } as unknown as Event);
-    flushMicrotasks();
-
-    expect(input.value).toBe('12,3');
-    expect(component.valorControl?.value).toBe('12,3');
-  }));
-
-  it('deve impedir teclas inválidas no campo de valor', () => {
-    const evento = {
-      key: 'a',
-      ctrlKey: false,
-      metaKey: false,
-      preventDefault: jasmine.createSpy('preventDefault'),
-    } as unknown as KeyboardEvent;
-
-    component.onValorKeydown(evento);
-
-    expect(evento.preventDefault).toHaveBeenCalled();
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
-  it('deve permitir teclas numéricas no campo de valor', () => {
-    const evento = {
-      key: '3',
-      ctrlKey: false,
-      metaKey: false,
-      preventDefault: jasmine.createSpy('preventDefault'),
-    } as unknown as KeyboardEvent;
-
-    component.onValorKeydown(evento);
-
-    expect(evento.preventDefault).not.toHaveBeenCalled();
+  it('deve criar o componente', () => {
+    expect(component).toBeTruthy();
   });
 
-  it('deve sanitizar o conteúdo colado no campo de valor', fakeAsync(() => {
-    const input = document.createElement('input');
-    input.value = '';
-    input.setSelectionRange(0, 0);
+  it('deve aceitar valor monetario valido', () => {
+    component.saqueForm.controls.valor.setValue('12,30');
 
-    const clipboardData = {
-      getData: jasmine.createSpy('getData').and.returnValue('abc12,3x'),
-    };
+    expect(component.saqueForm.controls.valor.value).toBe('12,30');
+    expect(component.saqueForm.valid).toBeTrue();
+  });
 
-    const evento = {
-      target: input,
-      clipboardData,
-      preventDefault: jasmine.createSpy('preventDefault'),
-    } as unknown as ClipboardEvent;
+  it('deve invalidar valor monetario com mais de duas casas decimais', () => {
+    component.saqueForm.controls.valor.setValue('12,345');
+    component.saqueForm.controls.valor.markAsTouched();
 
-    component.onValorPaste(evento);
-    flushMicrotasks();
-
-    expect(evento.preventDefault).toHaveBeenCalled();
-    expect(input.value).toBe('12,3');
-    expect(component.valorControl?.value).toBe('12,3');
-  }));
+    expect(component.saqueForm.controls.valor.hasError('currencyFormat')).toBeTrue();
+  });
 });

--- a/front-end/src/app/features/manager/services/pedidos-autocadastro.spec.ts
+++ b/front-end/src/app/features/manager/services/pedidos-autocadastro.spec.ts
@@ -1,6 +1,7 @@
-import { TestBed } from '@angular/core/testing';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
 import { API_URL } from '../../../core/configs/api.token';
 import { PedidosAutocadastroService } from './pedidos-autocadastro';
 
@@ -47,12 +48,13 @@ describe('PedidosAutocadastroService', () => {
 
     let pedidosOrdenados: unknown[] = [];
 
-    service.listar().subscribe((pedidos) => {
+    service.listar('12345678910').subscribe((pedidos) => {
       pedidosOrdenados = pedidos;
     });
 
-    const requisicao = httpTestingController.expectOne(
-      'http://localhost:3000/manager/pedidos-autocadastro',
+    const requisicao = httpTestingController.expectOne((request) =>
+      request.url === 'http://localhost:3000/manager/pedidos-autocadastro' &&
+      request.params.get('cpfGerente') === '12345678910'
     );
 
     expect(requisicao.request.method).toBe('GET');


### PR DESCRIPTION
## Descricao
Corrige o mapeamento dos tipos de movimentacao na tela de extrato para reconhecer os valores enviados pelo mock/front (`DEPOSITO`, `SAQUE` e `TRANSFERENCIA`) sem depender de acentos ou caixa.

Ajusta tambem os testes que bloqueavam a compilacao do runner do front, mantendo-os alinhados com os contratos atuais dos componentes e servicos.

## Tipo de Mudanca
- **FIX**: Correcao de bug.

## Guia de Testes
**Como reproduzir:**
1. A partir de `front-end`, executar `npx ng test --watch=false --browsers=ChromeHeadless --include src/app/features/client/pages/008-consulta-de-extrato/008-consulta-de-extrato.utils.spec.ts`.
2. A partir de `front-end`, executar `npx ng build --configuration development`.
3. Acessar a tela de extrato com movimentacoes de deposito, saque e transferencia.
4. Verificar se os rotulos, categorias e indicacao visual de entrada/saida aparecem corretamente.

**Resultado esperado:**
- Depositos aparecem como `Deposito`, categoria `Operacao bancaria` e entrada positiva.
- Saques aparecem como `Saque`, categoria `Operacao bancaria` e saida negativa.
- Transferencias aparecem como `Transferencia`, categoria `Transferencia`, diferenciando envio e recebimento.
- Filtro por periodo e agrupamento por data permanecem funcionando.
- Teste focado executado com sucesso: `TOTAL: 3 SUCCESS`.
- Build de desenvolvimento executado com sucesso.

## Screenshots
- Nao aplicavel. Ajuste validado por teste unitario focado e build do front.
