### PR TITLE
[BACKEND] [Issue — SAGA Alteração de Perfil do Cliente]

### DIFF
--- a/back-end/auth/pom.xml
+++ b/back-end/auth/pom.xml
@@ -21,7 +21,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId> </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/back-end/auth/src/main/java/com/bantads/auth/UsuarioSagaConsumer.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/UsuarioSagaConsumer.java
@@ -1,14 +1,19 @@
 package com.bantads.auth;
 
+import org.springframework.amqp.rabbit.annotation.Exchange;
+import org.springframework.amqp.rabbit.annotation.Queue;
+import org.springframework.amqp.rabbit.annotation.QueueBinding;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import com.bantads.auth.dto.AutocadastroInfoDTO;
+import com.bantads.auth.dto.ClienteAtualizadoEvent; 
 import com.bantads.auth.model.TipoUsuario;
-import com.bantads.auth.repository.UserRepository;
-import com.bantads.auth.security.Sha256SaltPasswordEncoder;
 import com.bantads.auth.model.User;
+import com.bantads.auth.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import com.bantads.auth.dto.AutocadastroInfoDTO;
 
 @Component
 public class UsuarioSagaConsumer {
@@ -17,12 +22,12 @@ public class UsuarioSagaConsumer {
     private UserRepository userRepository;
 
     @Autowired
-    private Sha256SaltPasswordEncoder passwordEncoder;
-
+    private PasswordEncoder passwordEncoder;
+   
     @Autowired
     private RabbitTemplate rabbitTemplate;
 
-    @RabbitListener(queues = "saga.autocadastro.auth")
+    @RabbitListener(queuesToDeclare = @Queue("saga.autocadastro.auth"))
     public void CriarUsuarioSaga(AutocadastroInfoDTO dto) {
         try{
             User novoUsuario = new User();
@@ -40,12 +45,29 @@ public class UsuarioSagaConsumer {
         }
     }
 
-    @RabbitListener(queues = "saga.autocadastro.auth.rollback")
+    @RabbitListener(queuesToDeclare = @Queue("saga.autocadastro.auth.rollback"))
     public void cancelarUsuarioSaga(AutocadastroInfoDTO dto) {
         userRepository.findByEmail(dto.getEmail())
             .ifPresent(user -> userRepository.delete(user));
         System.out.println("Rollback realizado: Usuário removido do MS Auth.");
-    
     }
 
+    @RabbitListener(bindings = @QueueBinding(
+        value = @Queue(value = "auth.cliente.atualizado.fila", durable = "true"),
+        exchange = @Exchange(value = "cliente.exchange", type = "direct"), // Alterado para 'direct'
+        key = "cliente.perfil.alterado" // Alterado para a chave exata do ms-cliente
+    ))
+    public void atualizarUsuarioSaga(ClienteAtualizadoEvent evento) {
+        try {
+            userRepository.findByReferenciaId(evento.cpf()).ifPresent(user -> {
+                if (evento.nome() != null) user.setNome(evento.nome());
+                if (evento.email() != null) user.setEmail(evento.email());
+                
+                userRepository.save(user);
+                System.out.println("MS-Auth: E-mail e Nome atualizados via Saga para o CPF: " + evento.cpf());
+            });
+        } catch (Exception e) {  
+            System.err.println("Erro Saga (MS-Auth): Não foi possível atualizar perfil. " + e.getMessage());
+        }
+    }
 }

--- a/back-end/auth/src/main/java/com/bantads/auth/dto/AutocadastroInfoDTO.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/dto/AutocadastroInfoDTO.java
@@ -1,0 +1,20 @@
+package com.bantads.auth.dto;
+
+import java.io.Serializable;
+
+public class AutocadastroInfoDTO implements Serializable {
+    private String cpf;
+    private String nome;
+    private String email;
+    private String senha;
+
+    public String getCpf() { return cpf; }
+    public String getNome() { return nome; }
+    public String getEmail() { return email; }
+    public String getSenha() { return senha; }
+
+    public void setCpf(String cpf) { this.cpf = cpf; }
+    public void setNome(String nome) { this.nome = nome; }
+    public void setEmail(String email) { this.email = email; }
+    public void setSenha(String senha) { this.senha = senha; }
+}

--- a/back-end/auth/src/main/java/com/bantads/auth/dto/ClienteAtualizadoEvent.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/dto/ClienteAtualizadoEvent.java
@@ -1,0 +1,10 @@
+package com.bantads.auth.dto;
+
+import java.io.Serializable;
+
+public record ClienteAtualizadoEvent(
+        String cpf,
+        String nome,
+        String email,
+        Double salario
+) implements Serializable {}

--- a/back-end/auth/src/main/java/com/bantads/auth/repository/UserRepository.java
+++ b/back-end/auth/src/main/java/com/bantads/auth/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface UserRepository extends MongoRepository<User, String> {
     Optional<User> 
     findByEmail(String email);
+
+    Optional<User> findByReferenciaId(String referenciaId);
 }

--- a/back-end/auth/src/main/java/com/bantads/config/RabbitMqConfiguracao.java
+++ b/back-end/auth/src/main/java/com/bantads/config/RabbitMqConfiguracao.java
@@ -1,0 +1,33 @@
+package com.bantads.auth.config;
+
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.support.converter.DefaultJackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMqConfiguracao {
+
+    @Bean
+    public Jackson2JsonMessageConverter conversorJsonRabbitMq() {
+        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter();
+        DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
+        // Ignora o __TypeId__ da mensagem e usa o tipo do método listener
+        typeMapper.setTypePrecedence(DefaultJackson2JavaTypeMapper.TypePrecedence.INFERRED);
+        converter.setJavaTypeMapper(typeMapper);
+        return converter;
+    }
+
+    @Bean
+    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+        ConnectionFactory connectionFactory,
+        Jackson2JsonMessageConverter conversorJsonRabbitMq
+    ) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(conversorJsonRabbitMq);
+        return factory;
+    }
+}

--- a/back-end/auth/src/main/resources/application.properties
+++ b/back-end/auth/src/main/resources/application.properties
@@ -8,3 +8,8 @@ spring.data.mongodb.uri=${MONGO_URI:mongodb://localhost:27017/ms_auth}
 
 # Segurança JWT
 app.jwt.secret=secret
+
+spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:guest}
+spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:guest}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - maven-repo:/root/.m2
       - /app/node_modules
     environment:
-    - SECRET=secret        # <- adicionar isso
+    - SECRET=secret        
     - PORT=8080
     restart: unless-stopped
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,9 @@ services:
       - ./back-end/api-gateway:/app
       - maven-repo:/root/.m2
       - /app/node_modules
+    environment:
+    - SECRET=secret        # <- adicionar isso
+    - PORT=8080
     restart: unless-stopped
 
   # =========== BANCOS DE DADOS ===========
@@ -68,8 +71,10 @@ services:
       - "8081:8080"
     depends_on:
       - mongodb-auth
+      - rabbitmq
     environment:
       - MONGO_URI=mongodb://mongodb-auth:27017/bantads_auth
+      - SPRING_RABBITMQ_HOST=rabbitmq
     volumes:
       - ./back-end/auth:/app
       - maven-repo:/root/.m2


### PR DESCRIPTION
## Pull Request Template

### Título do PR
[BACKEND] [Issue — SAGA Alteração de Perfil do Cliente]

---

## 📝 Descrição

Implementação do fluxo SAGA de alteração de perfil do cliente, propagando as mudanças de nome, email e salário para os microsserviços dependentes via RabbitMQ.

**Alterações realizadas:**

**ms-auth:**
- `UsuarioSagaConsumer.atualizarUsuarioSaga` escuta a fila `auth.cliente.atualizado.fila` e atualiza nome e email no MongoDB
- `RabbitMqConfiguracao` adicionada com `TypePrecedence.INFERRED` para resolver conflito de deserialização do `__TypeId__` entre pacotes diferentes
- Adicionado `findByReferenciaId` no `UserRepository`
- Adicionada dependência `spring-boot-starter-amqp` no `pom.xml`
- Adicionadas configurações RabbitMQ no `application.properties`

**docker-compose.yaml:**
- ms-auth agora depende do rabbitmq com variável `SPRING_RABBITMQ_HOST`
- Variável `SECRET` adicionada ao api-gateway para validação do JWT
---

## 🛠 Tipo de Mudança
- ✨ **FEAT**: Nova funcionalidade.


## 🧪 Guia de Testes

**Como reproduzir:**
1. Fazer login para obter o token (via gateway na porta `8080`):
```bash
curl -X POST http://localhost:8080/login \
  -H "Content-Type: application/json" \
  -d '{"login": "admin@bantads.com", "senha": "123456"}'
```

2. Alterar o perfil do cliente diretamente no ms-cliente (porta `8082`, bypass do gateway para teste):
```bash
curl -X PUT http://localhost:8082/clientes/12912861012 \
  -H "Content-Type: application/json" \
  -d '{"nome": "Catharyna Atualizada", "email": "atualizado@bantads.com", "salario": 12000.0}'
```
3. Verificar propagação no ms-auth:
```bash
docker compose logs ms-auth --tail=10
```

4. Confirmar no MongoDB que nome e email foram atualizados:
```bash
docker exec -it $(docker ps -qf "name=mongodb") mongosh \
  --eval "db.getSiblingDB('bantads_auth').usuario.find({referencia_id: '12912861012'}).pretty()"
```

**Resultado esperado:**
- `PUT /clientes/12912861012` retorna `200 OK`
- Log `MS-Auth: E-mail e Nome atualizados via Saga para o CPF: 12912861012` aparece no ms-auth
- MongoDB reflete o novo nome e email
- ms-conta loga `SAGA [Sucesso]` se o CPF possuir conta, ou `SAGA [Aviso]: CPF não possui conta. Ignorando evento.` caso contrário

##Screenshots
- 
<img width="599" height="20" alt="Captura de tela 2026-05-04 203736" src="https://github.com/user-attachments/assets/67e2cf6d-0004-4fb5-b283-aaaea0226346" />

- 
<img width="876" height="481" alt="Captura de tela 2026-05-04 201050" src="https://github.com/user-attachments/assets/79fb0b85-8093-43af-8262-dbd931b06782" />

<img width="959" height="226" alt="Captura de tela 2026-05-04 203919" src="https://github.com/user-attachments/assets/877222a7-d059-4fc5-89d3-dd61fe31e65d" />
