### PR TITLE
[FRONTEND | BACKEND] Corrige integração da aprovação de cliente

### DIFF
--- a/back-end/api-gateway/index.js
+++ b/back-end/api-gateway/index.js
@@ -49,7 +49,9 @@ function verifyJWT(req, res, next) {
             return res.status(500).json({ auth: false, message: 'Falha ao autenticar o token.' });
         }
 
-        req.userId = decoded.id; 
+        req.userId = decoded.id;
+        req.headers['x-usuario-cpf'] = decoded.cpf;
+        req.headers['x-usuario-tipo'] = decoded.tipo;
         next();
     });
 }

--- a/front-end/src/app/features/admin/services/gerentes.spec.ts
+++ b/front-end/src/app/features/admin/services/gerentes.spec.ts
@@ -97,4 +97,55 @@ describe('GerentesService', () => {
 
     expect(nomesCarregados).toEqual(['Geniéve', 'Godophredo', 'Gyândula']);
   });
+
+  it('deve inserir gerente no endpoint real do gateway', () => {
+    const gerente = {
+      cpf: '12345678901',
+      nome: 'Gerente Teste',
+      email: 'gerente.teste@bantads.com.br',
+      celular: '(41) 99999-0000',
+    };
+
+    service.inserir(gerente).subscribe();
+
+    const requisicao = httpTestingController.expectOne(
+      'http://localhost:3000/gerentes',
+    );
+
+    expect(requisicao.request.method).toBe('POST');
+    expect(requisicao.request.body).toEqual(gerente);
+    requisicao.flush(gerente);
+  });
+
+  it('deve atualizar gerente no endpoint real do gateway', () => {
+    const cpf = '12345678901';
+    const dadosGerente = {
+      nome: 'Gerente Atualizado',
+      email: 'gerente.atualizado@bantads.com.br',
+      celular: '(41) 98888-0000',
+    };
+
+    service.atualizar(cpf, dadosGerente).subscribe();
+
+    const requisicao = httpTestingController.expectOne(
+      `http://localhost:3000/gerentes/${cpf}`,
+    );
+
+    expect(requisicao.request.method).toBe('PUT');
+    expect(requisicao.request.body).toEqual(dadosGerente);
+    requisicao.flush(dadosGerente);
+  });
+
+  it('deve remover gerente no endpoint real do gateway', () => {
+    const cpf = '12345678901';
+
+    service.remover(cpf).subscribe();
+
+    const requisicao = httpTestingController.expectOne(
+      `http://localhost:3000/gerentes/${cpf}`,
+    );
+
+    expect(requisicao.request.method).toBe('DELETE');
+    requisicao.flush({});
+  });
 });

--- a/front-end/src/app/features/admin/services/gerentes.ts
+++ b/front-end/src/app/features/admin/services/gerentes.ts
@@ -42,14 +42,14 @@ export class GerentesService {
   }
 
   inserir(dadosGerente: any): Observable<any> {
-    return this.http.post(`${this.apiUrl}/admin/gerentes`, dadosGerente);
+    return this.http.post(`${this.apiUrl}/gerentes`, dadosGerente);
   }
 
   atualizar(cpf: string, dadosGerente: any): Observable<any> {
-    return this.http.put(`${this.apiUrl}/admin/atualizaPerfil/${cpf}`, dadosGerente);
+    return this.http.put(`${this.apiUrl}/gerentes/${cpf}`, dadosGerente);
   }
   
   remover(cpf: string) {
-    return this.http.delete<any>(`${this.apiUrl}/admin/gerentes/${cpf}`);
+    return this.http.delete<any>(`${this.apiUrl}/gerentes/${cpf}`);
   }
 }

--- a/front-end/src/app/features/client/services/client.service.spec.ts
+++ b/front-end/src/app/features/client/services/client.service.spec.ts
@@ -1,12 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { ClientService } from './client.service';
 import { API_URL } from '../../../core/configs/api.token';
 
 describe('ClientService', () => {
   let service: ClientService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -17,9 +18,56 @@ describe('ClientService', () => {
       ],
     });
     service = TestBed.inject(ClientService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('deve buscar perfil no endpoint real do gateway', () => {
+    const cpf = '76179646090';
+    const cliente = {
+      cpf,
+      nome: 'Cliente Teste',
+      email: 'cliente.teste@bantads.com.br',
+    };
+
+    service.buscaPerfil(cpf).subscribe((resposta) => {
+      expect(resposta as any).toEqual(cliente);
+    });
+
+    const requisicao = httpTestingController.expectOne(
+      `http://localhost:3000/clientes/${cpf}`,
+    );
+
+    expect(requisicao.request.method).toBe('GET');
+    requisicao.flush(cliente);
+  });
+
+  it('deve atualizar perfil no endpoint real do gateway', () => {
+    const cpf = '76179646090';
+    const dadosCliente = {
+      nome: 'Cliente Atualizado',
+      celular: '(41) 98888-0000',
+    };
+
+    service.atualizaUsuario(cpf, dadosCliente).subscribe();
+
+    const requisicao = httpTestingController.expectOne(
+      `http://localhost:3000/clientes/${cpf}`,
+    );
+
+    expect(requisicao.request.method).toBe('PUT');
+    expect(requisicao.request.body).toEqual(dadosCliente);
+    requisicao.flush({
+      balance: 1000,
+      managerName: 'Gerente Teste',
+      limit: 500,
+    });
   });
 });

--- a/front-end/src/app/features/client/services/client.service.ts
+++ b/front-end/src/app/features/client/services/client.service.ts
@@ -21,12 +21,12 @@ export class ClientService {
   private apiUrl = inject(API_URL);
 
   buscaPerfil(cpf: string): Observable<Client> {
-    return this.http.get<Client>(`${this.apiUrl}/cliente/perfil/${cpf}`);
+    return this.http.get<Client>(`${this.apiUrl}/clientes/${cpf}`);
   }
 
   atualizaUsuario(cpf: string, data: any): Observable<UpdateUserResponseApi> {
     return this.http.put<UpdateUserResponseApi>(
-      `${this.apiUrl}/cliente/alteracao-perfil/${cpf}`,
+      `${this.apiUrl}/clientes/${cpf}`,
       data
     );
   }

--- a/front-end/src/app/features/manager/services/pedidos-autocadastro.spec.ts
+++ b/front-end/src/app/features/manager/services/pedidos-autocadastro.spec.ts
@@ -53,7 +53,8 @@ describe('PedidosAutocadastroService', () => {
     });
 
     const requisicao = httpTestingController.expectOne((request) =>
-      request.url === 'http://localhost:3000/manager/pedidos-autocadastro' &&
+      request.url === 'http://localhost:3000/clientes' &&
+      request.params.get('filtro') === 'para_aprovar' &&
       request.params.get('cpfGerente') === '12345678910'
     );
 
@@ -74,5 +75,25 @@ describe('PedidosAutocadastroService', () => {
         dataSolicitacao: '2026-03-14T10:00:00.000Z',
       },
     ]);
+  });
+
+  it('deve aprovar cliente usando rota de clientes', () => {
+    service.aprovar('76179646090').subscribe();
+
+    const requisicao = httpTestingController.expectOne('http://localhost:3000/clientes/76179646090/aprovar');
+
+    expect(requisicao.request.method).toBe('POST');
+    expect(requisicao.request.body).toEqual({});
+    requisicao.flush({});
+  });
+
+  it('deve rejeitar cliente usando rota de clientes', () => {
+    service.rejeitar('76179646090', 'Documentos inconsistentes').subscribe();
+
+    const requisicao = httpTestingController.expectOne('http://localhost:3000/clientes/76179646090/rejeitar');
+
+    expect(requisicao.request.method).toBe('POST');
+    expect(requisicao.request.body).toEqual({ motivo: 'Documentos inconsistentes' });
+    requisicao.flush({});
   });
 });

--- a/front-end/src/app/features/manager/services/pedidos-autocadastro.ts
+++ b/front-end/src/app/features/manager/services/pedidos-autocadastro.ts
@@ -20,10 +20,12 @@ export class PedidosAutocadastroService {
   private readonly apiUrl = inject(API_URL);
 
   listar(cpfGerente: string): Observable<PedidoAutocadastro[]> {
-    const params = new HttpParams().set('cpfGerente', cpfGerente);
+    const params = new HttpParams()
+      .set('filtro', 'para_aprovar')
+      .set('cpfGerente', cpfGerente);
 
     return this.http
-      .get<PedidoAutocadastroResposta[]>(`${this.apiUrl}/manager/pedidos-autocadastro`, { params })
+      .get<PedidoAutocadastroResposta[]>(`${this.apiUrl}/clientes`, { params })
       .pipe(
         map((resposta) =>
           resposta
@@ -55,10 +57,10 @@ export class PedidosAutocadastroService {
   }
 
   rejeitar(cpf: string, motivo: string): Observable<any> {
-    return this.http.post(`${this.apiUrl}/manager/rejeitar-cliente/${cpf}`, { motivo });
+    return this.http.post(`${this.apiUrl}/clientes/${cpf}/rejeitar`, { motivo });
   }
 
   aprovar(cpf: string) {
-    return this.http.post<Client>(`${this.apiUrl}/manager/aprovar-cliente/${cpf}`, {});
+    return this.http.post<Client>(`${this.apiUrl}/clientes/${cpf}/aprovar`, {});
   }
 }


### PR DESCRIPTION
## Descrição

Esta PR consolida a revisão da PR #93 após merge na main e corrige integrações do Front-end com as rotas reais já expostas pelo API Gateway e pelos microsserviços.

A SAGA de aprovação cliente foi revisada contra a main atual, PRs posteriores e padrões das SAGAs já existentes. A implementação da SAGA foi mantida, pois o fluxo exige cliente, conta e auth, com estado durável e compensações.

Além do fluxo R10 de aprovação de cliente, a PR também corrige rotas antigas de mock usadas no Front-end para gerente e perfil de cliente, mantendo o escopo sem alteração no API Gateway.

## Tipo de Mudança

- FIX: Correção de bug.
- TEST: Atualização de testes.

## Mudanças

- Ajusta o Front-end de pedidos de autocadastro para usar as rotas reais de `/clientes`.
- Alinha listagem para `/clientes?filtro=para_aprovar`.
- Alinha aprovação para `/clientes/{cpf}/aprovar`.
- Alinha rejeição para `/clientes/{cpf}/rejeitar`.
- Faz o API Gateway propagar `X-Usuario-Cpf` e `X-Usuario-Tipo` a partir do JWT.
- Alinha o Front-end de gerentes para usar `/gerentes` e `/gerentes/{cpf}` em vez das rotas antigas de mock `/admin/...`.
- Alinha o Front-end de perfil do cliente para usar `/clientes/{cpf}` em busca e atualização de perfil.
- Atualiza testes dos services de gerentes e cliente para cobrir os endpoints reais do Gateway.

## Escopo

Não altera a branch original da PR #93.

Não refatora o MS Conta nesta PR. A extração de um serviço específico para aprovação cliente tem valor arquitetural, mas foi deixada para depois porque as PRs #97 e #99 abertas alteram Conta, RabbitMQ e repositórios relacionados, aumentando risco de conflito.

Também não corrige a duplicidade de configuração RabbitMQ do Auth aqui, pois as PRs #98 e #99 já tratam a remoção do arquivo antigo.

Não altera rotas do API Gateway para os ajustes de gerentes e perfil do cliente; apenas corrige o Front-end para consumir rotas já expostas.

## Guia de Testes

**Como reproduzir:**
1. Logar como gerente.
2. Acessar pedidos de autocadastro.
3. Listar clientes pendentes para aprovação.
4. Aprovar ou rejeitar um cliente pendente.
5. Verificar que as chamadas passam pelo API Gateway usando `/clientes`.
6. Acessar fluxos de gerente e perfil de cliente que usam os services atualizados.

**Resultado esperado:**
- A listagem usa `/clientes?filtro=para_aprovar`.
- A aprovação usa `/clientes/{cpf}/aprovar`.
- A rejeição usa `/clientes/{cpf}/rejeitar`.
- O MS Cliente recebe `X-Usuario-Cpf` e `X-Usuario-Tipo` propagados pelo Gateway.
- Os fluxos de gerente usam `/gerentes` e `/gerentes/{cpf}`.
- Os fluxos de perfil de cliente usam `/clientes/{cpf}`.

**Validações executadas:**
- `node --check back-end/api-gateway/index.js`
- `npx ng build --configuration development`
- `npx ng test --watch=false --browsers=ChromeHeadless --include "src/app/features/admin/services/gerentes.spec.ts" --include "src/app/features/client/services/client.service.spec.ts"` - 9 testes passaram.
- `git diff --check`
- Consulta ao NotebookLM DAC para confirmar o critério de Gateway como ponto único de entrada e uso de rotas canônicas REST.

## Screenshots

Alteração de integração sem mudança visual.
