### PR TITLE
[FRONTEND] Refatoração: Página Inicial e Tela de Saque (Issues #110 e #111)

### DIFF
--- a/front-end/mock-server.js
+++ b/front-end/mock-server.js
@@ -40,13 +40,11 @@ const gerarDataIsoBrasil = (data = new Date()) => {
 };
 
 //Login ------------------------------
-app.post("/auth/login", (req, res) => {
-  const { email, password } = req.body;
-
+app.post("/login", (req, res) => {
+  const { login, senha } = req.body; 
   const auths = getData("auth");
-
   const user = auths.find(
-    (u) => u.email === email && u.senha === password
+    (u) => u.email === login && u.senha === senha 
   );
 
   if (!user) {
@@ -66,7 +64,7 @@ app.post("/auth/login", (req, res) => {
     }
   });
 
-  console.log(`Login realizado: ${email}`);
+  console.log(`Login realizado: ${login}`);
 });
 
 // Autocadastro --------------------------

--- a/front-end/src/app/features/client/pages/pagina-inicial/pagina-inicial.ts
+++ b/front-end/src/app/features/client/pages/pagina-inicial/pagina-inicial.ts
@@ -1,10 +1,12 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, signal, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatIconModule } from '@angular/material/icon';
 import { CurrencyPipe } from '@angular/common';
 import { CardMenu } from '../../../../shared/components/card-menu/card-menu';
 import { Router } from '@angular/router';
+
 import { AuthService } from '../../../../core/auth/services/auth.service';
-import { HttpClient } from '@angular/common/http';
+import { ClientService } from '../../services/client.service';
 
 @Component({
   selector: 'app-pagina-inicial',
@@ -13,11 +15,12 @@ import { HttpClient } from '@angular/common/http';
   templateUrl: './pagina-inicial.html',
   styleUrl: './pagina-inicial.css',
 })
-export class PaginaInicial {
+export class PaginaInicial implements OnInit {
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
-  private readonly http = inject(HttpClient);
-
+  private readonly clientService = inject(ClientService);
+  private readonly destroyRef = inject(DestroyRef);
+  
   readonly saldo = signal(0);
   readonly nomeUsuario = signal('Cliente BanTads');
 
@@ -27,7 +30,9 @@ export class PaginaInicial {
       : `Pague o que me deve, ${this.nomeUsuario()}!`
   );
 
-  constructor() {
+  constructor() {}
+  
+  ngOnInit(): void {
     const currentUser = this.authService.currentUserValue;
 
     if (currentUser?.nome?.trim()) {
@@ -35,24 +40,25 @@ export class PaginaInicial {
     }
 
     if (currentUser?.cpf) {
-      this.carregarDadosConta(currentUser.cpf);
+      this.carregarDadosAPI(currentUser.cpf);
     } else {
-      console.error('Usuário não identificado');
+      console.error('Usuário não identificado na sessão');
     }
   }
 
-  private carregarDadosConta(cpf: string): void {
-    this.http.get<any>(`http://localhost:3000/contas/cpf/${cpf}`)
+  private carregarDadosAPI(cpf: string): void {
+    this.clientService.buscaDadosConta(cpf)
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (dadosConta) => {
+        next: (dadosConta: any) => {
           this.saldo.set(dadosConta.saldoDisponivel || 0);
 
           if (dadosConta.nome?.trim()) {
             this.nomeUsuario.set(dadosConta.nome.trim());
           }
         },
-        error: (erro) => {
-          console.error('Erro ao buscar dados da conta:', erro);
+        error: (erro: any) => {
+          console.error('Erro ao buscar dados da conta via Service:', erro);
         }
       });
   }

--- a/front-end/src/app/features/client/pages/saque-page/saque-page.component.spec.ts
+++ b/front-end/src/app/features/client/pages/saque-page/saque-page.component.spec.ts
@@ -1,85 +1,72 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialog } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
+import { provideNgxMask } from 'ngx-mask';
 
-import { AuthService } from '../../../../core/auth/services/auth.service';
-import { ClientAccountService } from '../../services/client-account.service';
 import { SaquePageComponent } from './saque-page.component';
+import { AuthService } from '../../../../core/auth/services/auth.service';
+import { ClientService } from '../../services/client.service';
+import { SaqueService } from '../../services/saque.service';
+import { ToastService } from '../../../../core/services/toast.service';
 
 describe('SaquePageComponent', () => {
   let component: SaquePageComponent;
   let fixture: ComponentFixture<SaquePageComponent>;
-  let httpTestingController: HttpTestingController;
+
+  let mockRouter = { 
+    navigate: jasmine.createSpy('navigate') 
+  };
+  
+  let mockToastService = {
+    success: jasmine.createSpy('success'),
+    error: jasmine.createSpy('error')
+  };
+
+  let mockAuthService = {
+    currentUserValue: { cpf: '12345678910' }
+  };
+
+  let mockClientService = {
+    buscaDadosConta: jasmine.createSpy('buscaDadosConta').and.returnValue(of({
+      numeroConta: '123456-7',
+      saldoDisponivel: 125.49,
+      limite: 5000
+    }))
+  };
+
+  let mockSaqueService = {
+    realizarSaque: jasmine.createSpy('realizarSaque').and.returnValue(of({
+      message: 'Saque realizado com sucesso!',
+      novoSaldoOrigem: 25.49
+    }))
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SaquePageComponent],
+      imports: [SaquePageComponent, BrowserAnimationsModule], 
       providers: [
-        {
-          provide: MatDialog,
-          useValue: {
-            open: jasmine.createSpy('open'),
-          },
-        },
-        {
-          provide: Router,
-          useValue: {
-            navigate: jasmine.createSpy('navigate'),
-          },
-        },
-        {
-          provide: AuthService,
-          useValue: {
-            currentUserValue: {
-              cpf: '12345678910',
-            },
-          },
-        },
-        {
-          provide: ClientAccountService,
-          useValue: {
-            getCurrentAccount: () =>
-              of({
-                accountId: 'client-main-account',
-                branch: '0001',
-                accountNumber: '123456-7',
-                holderName: 'Artur Falavinha',
-                holderDocument: '12345678910',
-                availableBalance: 125.49,
-                limit: 5000,
-                manager: 'Gerente Teste',
-                transactions: [],
-              }),
-            withdrawFromCurrentAccount: jasmine
-              .createSpy('withdrawFromCurrentAccount')
-              .and.returnValue(of(null)),
-          },
-        },
-        provideHttpClient(),
-        provideHttpClientTesting(),
-      ],
+        provideNgxMask(),
+        { provide: Router, useValue: mockRouter },
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: ClientService, useValue: mockClientService },
+        { provide: SaqueService, useValue: mockSaqueService },
+        { provide: ToastService, useValue: mockToastService }
+      ]
     }).compileComponents();
 
-    httpTestingController = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(SaquePageComponent);
     component = fixture.componentInstance;
-    httpTestingController.expectOne('http://localhost:3000/contas/cpf/12345678910').flush({
-      numeroConta: '123456-7',
-      saldoDisponivel: 125.49,
-      limite: 5000,
-    });
-    fixture.detectChanges();
+    
+    fixture.detectChanges(); 
   });
 
-  afterEach(() => {
-    httpTestingController.verify();
-  });
-
-  it('deve criar o componente', () => {
+  it('deve criar o componente e carregar o saldo no ngOnInit', () => {
     expect(component).toBeTruthy();
+    
+    expect(mockClientService.buscaDadosConta).toHaveBeenCalledWith('12345678910');
+    
+    expect(component.saldoDisponivel).toBe(5125.49);
   });
 
   it('deve aceitar valor monetario valido', () => {

--- a/front-end/src/app/features/client/pages/saque-page/saque-page.component.ts
+++ b/front-end/src/app/features/client/pages/saque-page/saque-page.component.ts
@@ -1,45 +1,20 @@
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
-import {
-  AbstractControl,
-  FormBuilder,
-  ReactiveFormsModule,
-  ValidationErrors,
-  ValidatorFn,
-  Validators,
-} from '@angular/forms';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AbstractControl, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { finalize } from 'rxjs';
 
 import { AuthService } from '../../../../core/auth/services/auth.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ClientService } from '../../services/client.service';
+import { SaqueService } from '../../services/saque.service';
+
 import { InputPrimaryComponent } from '../../../../shared/components/input-primary/input-primary.component';
 import { formatCurrency } from '../../../../shared/utils/formatters';
+import { normalizarValorMonetario } from '../../../../shared/utils/currency.utils';
 import { DepositConfirmationModalComponent } from '../../components/deposit-confirmation-modal.component';
-
-const amountPattern = /^\d+(?:[.,]\d{1,2})?$/;
-
-const saqueAmountValidator: ValidatorFn = (
-  control: AbstractControl
-): ValidationErrors | null => {
-  const rawValue = String(control.value ?? '').trim();
-
-  if (!rawValue) {
-    return null;
-  }
-
-  const normalizedValue = normalizarValorMonetario(rawValue);
-
-  if (!rawValue || normalizedValue === null) {
-    return { currencyFormat: true };
-  }
-
-  if (!Number.isFinite(normalizedValue) || normalizedValue <= 0) {
-    return { positiveAmount: true };
-  }
-
-  return null;
-};
+import { saqueAmountValidator } from '../../../../shared/utils/saque.validators';
 
 @Component({
   selector: 'app-saque-page',
@@ -54,13 +29,16 @@ const saqueAmountValidator: ValidatorFn = (
   styleUrls: ['./saque-page.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SaquePageComponent {
+export class SaquePageComponent implements OnInit {
   private readonly formBuilder = inject(FormBuilder);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly router = inject(Router);
-  private readonly http = inject(HttpClient);
   private readonly authService = inject(AuthService);
-
+  private readonly saqueService = inject(SaqueService);
+  private readonly clientService = inject(ClientService);
+  private readonly toastService = inject(ToastService);
+  private readonly destroyRef = inject(DestroyRef);
+  
   readonly formatCurrency = formatCurrency;
   readonly saqueForm = this.formBuilder.nonNullable.group({
     valor: ['', [Validators.required, saqueAmountValidator]],
@@ -73,13 +51,15 @@ export class SaquePageComponent {
   isSubmitting = false;
   exibirModalConfirmacao = false;
 
-  constructor() {
+  constructor() {}
+
+  ngOnInit(): void {
     const usuarioLogado = this.authService.currentUserValue;
 
     if (usuarioLogado?.cpf) {
       this.carregarSaldo(usuarioLogado.cpf);
     } else {
-      console.error('Usuário não identificado');
+      this.toastService.error('Erro de Sessão', 'Utilizador não identificado.');
     }
   }
 
@@ -156,7 +136,6 @@ export class SaquePageComponent {
 
   confirmarSaque(): void {
     const valorNumerico = this.parseValor(this.valorControl.value);
-
     if (!valorNumerico) {
       this.valorControl.setErrors({ positiveAmount: true });
       return;
@@ -164,53 +143,49 @@ export class SaquePageComponent {
 
     this.isSubmitting = true;
 
-    const payload = {
+    this.saqueService.realizarSaque({
       contaOrigem: this.minhaContaLogada,
       valor: valorNumerico,
-    };
-
-    this.http
-      .post<any>('http://localhost:3000/transacoes/saque', payload)
-      .pipe(
-        finalize(() => {
-          this.isSubmitting = false;
-          this.exibirModalConfirmacao = false;
-        })
-      )
-      .subscribe({
-        next: () => {
-          const cpf = this.authService.currentUserValue?.cpf;
-          if (cpf) {
-            this.carregarSaldo(cpf);
-          }
-
-          this.router.navigate(['/cliente/saque/sucesso'], {
-            state: {
-              valor: valorNumerico,
-              dataHora: new Date().toISOString(),
-            },
-          });
-        },
-        error: (erro) => {
-          this.valorControl.setErrors({ saldoInsuficiente: true });
-          console.error(erro);
-        },
-      });
-  }
-
-  private carregarSaldo(cpf: string): void {
-    this.http.get<any>(`http://localhost:3000/contas/cpf/${cpf}`).subscribe({
-      next: (dadosConta) => {
-        this.minhaContaLogada = dadosConta.numeroConta;
-        const limite = dadosConta.limite || 0;
-        this.saldoDisponivel = (dadosConta.saldoDisponivel || 0) + limite;
+    })
+    .pipe(
+      takeUntilDestroyed(this.destroyRef),
+      finalize(() => {
+        this.isSubmitting = false;
+        this.exibirModalConfirmacao = false;
         this.changeDetectorRef.markForCheck();
+      })
+    )
+    .subscribe({
+      next: () => {
+        const cpf = this.authService.currentUserValue?.cpf;
+        if (cpf) this.carregarSaldo(cpf);
+        this.toastService.success('Sucesso', 'Saque realizado com sucesso!');
+        this.router.navigate(['/cliente/saque/sucesso'], {
+          state: { valor: valorNumerico, dataHora: new Date().toISOString() },
+        });
       },
-      error: (erro) => {
-        console.error('Erro ao buscar saldo:', erro);
-        this.changeDetectorRef.markForCheck();
+      error: () => {
+        this.valorControl.setErrors({ saldoInsuficiente: true });
+        this.toastService.error('Operação recusada', 'Não foi possível processar o saque.');
       },
     });
+  }
+
+ private carregarSaldo(cpf: string): void {
+    this.clientService.buscaDadosConta(cpf)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (dadosConta) => {
+          this.minhaContaLogada = dadosConta.numeroConta;
+          const limite = dadosConta.limite || 0;
+          this.saldoDisponivel = (dadosConta.saldoDisponivel || 0) + limite;
+          this.changeDetectorRef.markForCheck();
+        },
+        error: () => {
+          this.toastService.error('Erro', 'Falha ao buscar saldo.');
+          this.changeDetectorRef.markForCheck();
+        },
+      });
   }
 
   private hasFieldError(control: AbstractControl): boolean {
@@ -221,20 +196,4 @@ export class SaquePageComponent {
     const normalizedValue = normalizarValorMonetario(rawValue);
     return normalizedValue ?? 0;
   }
-}
-
-function normalizarValorMonetario(rawValue: string): number | null {
-  const cleanedValue = rawValue
-    .replace(/R\$\s?/g, '')
-    .replace(/\./g, '')
-    .replace(',', '.')
-    .trim();
-
-  if (!cleanedValue || !amountPattern.test(cleanedValue.replace('.', ','))) {
-    return null;
-  }
-
-  const normalizedValue = Number(cleanedValue);
-
-  return Number.isFinite(normalizedValue) ? normalizedValue : null;
 }

--- a/front-end/src/app/features/client/services/client.service.ts
+++ b/front-end/src/app/features/client/services/client.service.ts
@@ -31,4 +31,8 @@ export class ClientService {
     );
   }
 
+  buscaDadosConta(cpf: string): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/contas/cpf/${cpf}`);
+  }
+
 }

--- a/front-end/src/app/features/client/services/saque.service.ts
+++ b/front-end/src/app/features/client/services/saque.service.ts
@@ -1,9 +1,16 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
+import { API_URL } from '../../../core/configs/api.token';
+import { HttpClient } from '@angular/common/http';
 
-export interface ContaResumo {
-  saldo: number;
-  limite: number;
+export interface SaqueRequest {
+  contaOrigem: string;
+  valor: number;
+}
+
+export interface SaqueResponse {
+  message: string;
+  novoSaldoOrigem: number;
 }
 
 @Injectable({
@@ -11,27 +18,10 @@ export interface ContaResumo {
 })
 export class SaqueService {
 
-  private contaMock: ContaResumo = {
-    saldo: 5125.49,
-    limite: 5000.00,
-  };
+  private readonly http = inject(HttpClient);
+  private readonly apiBaseUrl = inject(API_URL);
 
-  getSaldoDisponivel(): Observable<ContaResumo> {
-    return of(this.contaMock);
-  }
-
-  realizarSaque(valor: number): Observable<boolean> {
-    if (valor <= 0) {
-      return throwError(() => new Error('Valor do saque deve ser maior que zero.'));
-    }
-
-    const saldoTotal = this.contaMock.saldo + this.contaMock.limite;
-
-    if (valor > saldoTotal) {
-      return throwError(() => new Error('Saldo insuficiente para este saque.'));
-    }
-
-    this.contaMock.saldo -= valor;
-    return of(true);
+  realizarSaque(request: SaqueRequest): Observable<SaqueResponse> {
+    return this.http.post<SaqueResponse>(`${this.apiBaseUrl}/transacoes/saque`, request);
   }
 }

--- a/front-end/src/app/shared/utils/currency.utils.ts
+++ b/front-end/src/app/shared/utils/currency.utils.ts
@@ -1,0 +1,17 @@
+const amountPattern = /^\d+(?:[.,]\d{1,2})?$/;
+
+export function normalizarValorMonetario(rawValue: string): number | null {
+  const cleanedValue = rawValue
+    .replace(/R\$\s?/g, '')
+    .replace(/\./g, '')
+    .replace(',', '.')
+    .trim();
+
+  if (!cleanedValue || !amountPattern.test(cleanedValue.replace('.', ','))) {
+    return null;
+  }
+
+  const normalizedValue = Number(cleanedValue);
+
+  return Number.isFinite(normalizedValue) ? normalizedValue : null;
+}

--- a/front-end/src/app/shared/utils/saque.validators.ts
+++ b/front-end/src/app/shared/utils/saque.validators.ts
@@ -1,0 +1,24 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { normalizarValorMonetario } from '../../shared/utils/currency.utils';
+
+export const saqueAmountValidator: ValidatorFn = (
+  control: AbstractControl
+): ValidationErrors | null => {
+  const rawValue = String(control.value ?? '').trim();
+
+  if (!rawValue) {
+    return null;
+  }
+
+  const normalizedValue = normalizarValorMonetario(rawValue);
+
+  if (!rawValue || normalizedValue === null) {
+    return { currencyFormat: true };
+  }
+
+  if (!Number.isFinite(normalizedValue) || normalizedValue <= 0) {
+    return { positiveAmount: true };
+  }
+
+  return null;
+};


### PR DESCRIPTION
## 📝 Descrição
Este PR resolve as Issues #110 e #111, aplicando uma refatoração baseada em princípios SOLID e boas práticas do Angular.
**Resolução da Issue #110 (Página Inicial):**
- Remoção do `HttpClient` direto no componente `pagina-inicial.ts`.
- Delegação da chamada da API para o método `buscaDadosConta` no `ClientService`.
- Migração da lógica de inicialização do `constructor` para o `ngOnInit`.

**Resolução da Issue #111 (Tela de Saque):**
- Remoção do `HttpClient` e extração de chamadas para o `SaqueService`.
- Extração da lógica de formatação monetária para `shared/utils/currency.utils.ts` e do validador reativo para `saque.validators.ts`.
- Remoção de `any` e URLs "chumbadas" (`localhost:3000`), substituídas por interfaces próprias (`SaqueRequest`, `SaqueResponse`) e injeção do token global `API_URL`.
- Substituição de `console.error` silenciosos por feedback em tela utilizando o `ToastService`.
- Adição de `takeUntilDestroyed` em todas as *subscriptions* da tela.
- O arquivo `.spec.ts` foi totalmente reescrito para abandonar o `HttpTestingController` e adotar Mocks limpos das novas dependências de serviço, além da inclusão do `provideNgxMask()`.

## 🛠 Tipo de Mudança
- ♻️ **REFACTOR**: Melhoria de código sem alterar comportamento.

## 🧪 Guia de Testes
**Como reproduzir:**
(foi testado com mock server pois ainda não sei se temos o fluxo completo do backend para testar essas alterações)
1. Suba o Mock Server atualizado na porta 3000 e rode o Front-end (`ng serve`).
2. Acesse a aplicação e faça o login com um cliente válido
3. Na **Página Inicial**, confira no painel *Network* se os dados da conta são carregados perfeitamente através do `ClientService`.
4. Acesse a rota de **Saque**:
   - Tente digitar valores negativos ou letras para validar a atuação do `saqueAmountValidator` agora isolado.
   - Tente sacar um valor superior ao saldo+limite e confirme a aparição do *Toast* de notificação de erro.
   - Realize um saque válido e confirme o redirecionamento com a notificação de sucesso.
5. No terminal, rode a suíte de testes: 
   `npx ng test --include src/app/features/client/pages/saque-page/saque-page.component.spec.ts --watch=false`

**Resultado esperado:**
- A aplicação deve fluir normalmente como o fluxo existente já está
- Os *Toasts* devem aparecer substituindo os erros de console.
- Os testes automatizados da tela de saque devem passar 100% com as novas injeções.

## 📸 Screenshots
Testes para a issue 110:
<img width="1319" height="605" alt="Captura de tela 2026-05-17 154007" src="https://github.com/user-attachments/assets/09fc5227-314f-458b-918f-8d29db31d19a" />

<img width="1322" height="609" alt="Captura de tela 2026-05-17 154022" src="https://github.com/user-attachments/assets/07018cc4-5a7f-4253-a6ed-986bc86c9b55" />

Testes para a issue 111:
<img width="1281" height="598" alt="Captura de tela 2026-05-17 161320" src="https://github.com/user-attachments/assets/a3756b0d-ada3-43ff-80d1-99ef8f4f3315" />

<img width="615" height="267" alt="Captura de tela 2026-05-17 161358" src="https://github.com/user-attachments/assets/1c136058-dfb5-427b-a44c-ebbde1885b43" />

<img width="670" height="395" alt="Captura de tela 2026-05-17 161420" src="https://github.com/user-attachments/assets/d06a4819-d06b-450f-8795-64af63e3b254" />

<img width="1311" height="600" alt="Captura de tela 2026-05-17 161724" src="https://github.com/user-attachments/assets/1fe3414a-3204-4c9b-bb30-bc2efa2fa490" />

<img width="851" height="132" alt="Captura de tela 2026-05-17 164025" src="https://github.com/user-attachments/assets/a90c9546-774e-4146-9650-eafc976f77a7" />