### PR TITLE
[FRONTEND | BACKEND] #100 Centralizar consultas gerenciais de clientes

### DIFF
--- a/back-end/cliente/src/main/java/com/bantads/cliente/controller/ClienteController.java
+++ b/back-end/cliente/src/main/java/com/bantads/cliente/controller/ClienteController.java
@@ -27,6 +27,9 @@ public class ClienteController {
         if ("para_aprovar".equalsIgnoreCase(filtro)) {
             return ResponseEntity.ok(clienteService.listarParaAprovar(cpfGerenteSolicitante, tipoUsuario, cpfGerente));
         }
+        if ("adm_relatorio_clientes".equalsIgnoreCase(filtro)) {
+            return ResponseEntity.ok(clienteService.listarRelatorioAdministrativo(tipoUsuario));
+        }
         return ResponseEntity.ok(clienteService.listarTodos());
     }
 
@@ -37,8 +40,12 @@ public class ClienteController {
     }
 
     @GetMapping("/{cpf}")
-    public ResponseEntity<ClienteResponseDTO> consultarCliente(@PathVariable String cpf) {
-        return ResponseEntity.ok(clienteService.buscarPorCpf(cpf));
+    public ResponseEntity<ClienteResponseDTO> consultarCliente(
+        @PathVariable String cpf,
+        @RequestHeader(value = "X-Usuario-Cpf", required = false) String cpfUsuario,
+        @RequestHeader(value = "X-Usuario-Tipo", required = false) String tipoUsuario
+    ) {
+        return ResponseEntity.ok(clienteService.buscarPorCpf(cpf, cpfUsuario, tipoUsuario));
     }
 
     @PutMapping("/{cpf}")

--- a/back-end/cliente/src/main/java/com/bantads/cliente/dto/ClienteResponseDTO.java
+++ b/back-end/cliente/src/main/java/com/bantads/cliente/dto/ClienteResponseDTO.java
@@ -21,12 +21,19 @@ public class ClienteResponseDTO {
     private String estado;
 
     public static ClienteResponseDTO fromEntity(Cliente c) {
+        return fromEntity(c, false);
+    }
+
+    public static ClienteResponseDTO fromEntity(Cliente c, boolean incluirSalario) {
         ClienteResponseDTO dto = new ClienteResponseDTO();
         dto.setCpf(c.getCpf());
         dto.setNome(c.getNome());
         dto.setEmail(c.getEmail());
         dto.setTelefone(c.getTelefone());
-        dto.setSalario(c.getSalario());
+
+        if (incluirSalario) {
+            dto.setSalario(c.getSalario());
+        }
         
         dto.setCep(c.getCep());
         dto.setLogradouro(c.getLogradouro());

--- a/back-end/cliente/src/main/java/com/bantads/cliente/dto/ClienteResponseDTO.java
+++ b/back-end/cliente/src/main/java/com/bantads/cliente/dto/ClienteResponseDTO.java
@@ -10,6 +10,7 @@ public class ClienteResponseDTO {
     private String nome;
     private String email;
     private String telefone;
+    private Double salario;
     
     private String cep;
     private String logradouro;
@@ -25,6 +26,7 @@ public class ClienteResponseDTO {
         dto.setNome(c.getNome());
         dto.setEmail(c.getEmail());
         dto.setTelefone(c.getTelefone());
+        dto.setSalario(c.getSalario());
         
         dto.setCep(c.getCep());
         dto.setLogradouro(c.getLogradouro());

--- a/back-end/cliente/src/main/java/com/bantads/cliente/service/ClienteService.java
+++ b/back-end/cliente/src/main/java/com/bantads/cliente/service/ClienteService.java
@@ -8,11 +8,13 @@ public interface ClienteService {
 
     void autocadastrar(AutocadastroInfoDTO dto);
 
-    ClienteResponseDTO buscarPorCpf(String cpf);
+    ClienteResponseDTO buscarPorCpf(String cpf, String cpfUsuario, String tipoUsuario);
 
     List<ClienteParaAprovarResponseDTO> listarParaAprovar(String cpfGerenteSolicitante, String tipoUsuario, String cpfGerenteFiltro);
 
     List<ClienteResponseDTO> listarTodos();
+
+    List<ClienteResponseDTO> listarRelatorioAdministrativo(String tipoUsuario);
 
     void alterarPerfil(String cpf, PerfilInfoDTO dto);
 

--- a/back-end/cliente/src/main/java/com/bantads/cliente/service/ClienteServiceImpl.java
+++ b/back-end/cliente/src/main/java/com/bantads/cliente/service/ClienteServiceImpl.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 public class ClienteServiceImpl implements ClienteService {
 
     private static final String TIPO_GERENTE = "GERENTE";
+    private static final String TIPO_ADMIN = "ADMIN";
     private static final List<StatusSagaAprovacaoCliente> STATUS_ATIVOS = List.of(
         StatusSagaAprovacaoCliente.INICIADA,
         StatusSagaAprovacaoCliente.AGUARDANDO_CONTA,
@@ -104,10 +105,10 @@ public class ClienteServiceImpl implements ClienteService {
     }
 
     @Override
-    public ClienteResponseDTO buscarPorCpf(String cpf) {
+    public ClienteResponseDTO buscarPorCpf(String cpf, String cpfUsuario, String tipoUsuario) {
         Cliente cliente = clienteRepository.findById(cpf)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Cliente nao encontrado"));
-        return ClienteResponseDTO.fromEntity(cliente);
+        return ClienteResponseDTO.fromEntity(cliente, podeConsultarSalario(cliente, cpfUsuario, tipoUsuario));
     }
 
     @Override
@@ -130,6 +131,16 @@ public class ClienteServiceImpl implements ClienteService {
         return clienteRepository.findByStatus(StatusCliente.APROVADO)
                 .stream()
                 .map(ClienteResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ClienteResponseDTO> listarRelatorioAdministrativo(String tipoUsuario) {
+        validarAdmin(tipoUsuario);
+
+        return clienteRepository.findByStatus(StatusCliente.APROVADO)
+                .stream()
+                .map(cliente -> ClienteResponseDTO.fromEntity(cliente, true))
                 .collect(Collectors.toList());
     }
 
@@ -251,6 +262,27 @@ public class ClienteServiceImpl implements ClienteService {
         if (!TIPO_GERENTE.equalsIgnoreCase(tipoUsuario)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Usuario autenticado nao e gerente");
         }
+    }
+
+    private void validarAdmin(String tipoUsuario) {
+        if (estaEmBranco(tipoUsuario)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Contexto de usuario autenticado ausente");
+        }
+        if (!TIPO_ADMIN.equalsIgnoreCase(tipoUsuario)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Usuario autenticado nao e administrador");
+        }
+    }
+
+    private boolean podeConsultarSalario(Cliente cliente, String cpfUsuario, String tipoUsuario) {
+        if (TIPO_ADMIN.equalsIgnoreCase(tipoUsuario)) {
+            return true;
+        }
+
+        if (estaEmBranco(cpfUsuario)) {
+            return false;
+        }
+
+        return cpfUsuario.equals(cliente.getCpf()) || cpfUsuario.equals(cliente.getCpfGerenteResponsavel());
     }
 
     private void validarAcessoSaga(SagaAprovacaoCliente saga, String cpfGerenteSolicitante) {

--- a/front-end/src/app/core/services/consultas-gerenciais.service.ts
+++ b/front-end/src/app/core/services/consultas-gerenciais.service.ts
@@ -1,0 +1,382 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, forkJoin, map, of, switchMap } from 'rxjs';
+
+import { ClienteService } from './cliente.service';
+import { ContaService } from './conta.service';
+import { GerentesService } from './gerentes.service';
+import {
+  ClienteResponse,
+  DadosClienteResponse,
+} from '../../shared/models/cliente.models';
+import { Gerente } from '../../shared/models/gerente';
+import {
+  ClienteCarteira,
+  ClienteDetalhado,
+  ContaConsulta,
+  InformacoesMelhorCliente,
+  RelatorioCliente,
+} from '../../shared/models/consultas-gerenciais';
+
+type ClienteConsulta = DadosClienteResponse & Partial<ClienteResponse>;
+type ValorNumerico = number | string | null | undefined;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ConsultasGerenciaisService {
+  private readonly clienteService = inject(ClienteService);
+  private readonly contaService = inject(ContaService);
+  private readonly gerentesService = inject(GerentesService);
+
+  listarRelatorioClientes(): Observable<RelatorioCliente[]> {
+    return forkJoin({
+      clientes: this.clienteService.listarRelatorioClientes(),
+      gerentes: this.gerentesService.listar(),
+    }).pipe(
+      switchMap(({ clientes, gerentes }) =>
+        this.criarMapaContasPorCliente(clientes).pipe(
+          map((contasPorCliente) =>
+            clientes
+              .map((cliente) =>
+                this.mapearRelatorioCliente(
+                  cliente,
+                  contasPorCliente.get(this.normalizarDocumento(cliente.cpf)),
+                  gerentes,
+                ),
+              )
+              .sort((atual, proximo) =>
+                atual.nomeCliente.localeCompare(proximo.nomeCliente, 'pt-BR'),
+              ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  listarClientesDoGerente(cpfGerente: string): Observable<ClienteCarteira[]> {
+    const cpfGerenteNormalizado = this.normalizarDocumento(cpfGerente);
+
+    if (!cpfGerenteNormalizado) {
+      return of([]);
+    }
+
+    return this.clienteService.listarTodosClientes().pipe(
+      switchMap((clientes) =>
+        this.criarMapaContasPorCliente(clientes).pipe(
+          map((contasPorCliente) =>
+            clientes
+              .map((cliente) => ({
+                cliente,
+                conta: contasPorCliente.get(this.normalizarDocumento(cliente.cpf)),
+              }))
+              .filter(({ cliente, conta }) =>
+                this.resolverCpfGerente(
+                  conta,
+                  cliente.cpfGerente,
+                  cliente.cpfGerenteResponsavel,
+                ) === cpfGerenteNormalizado,
+              )
+              .map(({ cliente, conta }) =>
+                this.mapearClienteCarteira(cliente, conta),
+              )
+              .sort((atual, proximo) =>
+                atual.nome.localeCompare(proximo.nome, 'pt-BR'),
+              ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  obterClienteDetalhadoPorCpf(cpf: string): Observable<ClienteDetalhado | null> {
+    const cpfNormalizado = this.normalizarDocumento(cpf);
+
+    if (!cpfNormalizado) {
+      return of(null);
+    }
+
+    return forkJoin({
+      clientes: this.clienteService.listarTodosClientes(),
+      gerentes: this.gerentesService.listar(),
+    }).pipe(
+      switchMap(({ clientes, gerentes }) => {
+        const cliente = clientes.find(
+          (item) => this.normalizarDocumento(item.cpf) === cpfNormalizado,
+        );
+
+        if (!cliente) {
+          return of(null);
+        }
+
+        return this.contaService.buscarPerfilContaPorCpf(cpfNormalizado).pipe(
+          map((conta) => this.mapearClienteDetalhado(cliente, conta, gerentes)),
+        );
+      }),
+    );
+  }
+
+  listarMelhoresClientes(cpfGerente?: string): Observable<InformacoesMelhorCliente[]> {
+    const cpfGerenteNormalizado =
+      cpfGerente === undefined ? '' : this.normalizarDocumento(cpfGerente);
+
+    if (cpfGerente !== undefined && !cpfGerenteNormalizado) {
+      return of([]);
+    }
+
+    return this.clienteService.listarMelhoresClientes().pipe(
+      switchMap((clientes) =>
+        this.criarMapaContasPorCliente(clientes).pipe(
+          map((contasPorCliente) =>
+            clientes
+              .map((cliente) => ({
+                cliente,
+                conta: contasPorCliente.get(this.normalizarDocumento(cliente.cpf)),
+              }))
+              .filter(
+                ({ cliente, conta }) =>
+                  (!!conta || this.temValorNumerico(cliente.saldo)) &&
+                  (!cpfGerenteNormalizado ||
+                    this.resolverCpfGerente(
+                      conta,
+                      cliente.cpfGerente,
+                      cliente.cpfGerenteResponsavel,
+                    ) === cpfGerenteNormalizado),
+              )
+              .map(({ cliente, conta }) =>
+                this.mapearMelhorCliente(cliente, conta),
+              )
+              .sort((atual, proximo) => proximo.saldo - atual.saldo)
+              .slice(0, 3),
+          ),
+        ),
+      ),
+    );
+  }
+
+  private criarMapaContasPorCliente(
+    clientes: ClienteConsulta[],
+  ): Observable<Map<string, ContaConsulta>> {
+    const consultas = clientes
+      .map((cliente) => this.normalizarDocumento(cliente.cpf))
+      .filter((cpf) => !!cpf)
+      .map((cpf) =>
+        this.contaService.buscarPerfilContaPorCpf(cpf).pipe(
+          map((conta) => ({
+            cpf,
+            conta,
+          })),
+        ),
+      );
+
+    if (consultas.length === 0) {
+      return of(new Map<string, ContaConsulta>());
+    }
+
+    return forkJoin(consultas).pipe(
+      map((respostas) => {
+        const contasPorCliente = new Map<string, ContaConsulta>();
+
+        respostas.forEach(({ cpf, conta }) => {
+          if (conta) {
+            contasPorCliente.set(cpf, conta);
+          }
+        });
+
+        return contasPorCliente;
+      }),
+    );
+  }
+
+  private mapearRelatorioCliente(
+    cliente: ClienteConsulta,
+    conta: ContaConsulta | undefined,
+    gerentes: Gerente[],
+  ): RelatorioCliente {
+    const cpfGerente = this.resolverCpfGerente(
+      conta,
+      cliente.cpfGerente,
+      cliente.cpfGerenteResponsavel,
+    );
+
+    return {
+      cpfCliente: this.normalizarDocumento(cliente.cpf) || '-',
+      nomeCliente: this.resolverTexto(cliente.nome),
+      emailCliente: this.resolverTexto(cliente.email),
+      salario: this.resolverNumero(cliente.salario),
+      numeroConta: this.resolverTexto(conta?.numero, conta?.accountNumber, cliente.numeroConta),
+      saldo: this.resolverNumero(conta?.saldo, conta?.availableBalance, cliente.saldo),
+      limite: this.resolverNumero(conta?.limite, conta?.limit, cliente.limite),
+      cpfGerente: cpfGerente || '-',
+      nomeGerente: this.resolverNomeGerente(cpfGerente, gerentes, conta, cliente.nomeGerente),
+    };
+  }
+
+  private mapearClienteCarteira(
+    cliente: ClienteConsulta,
+    conta: ContaConsulta | undefined,
+  ): ClienteCarteira {
+    const cpfCliente = this.normalizarDocumento(cliente.cpf);
+    const numeroConta = this.resolverTexto(conta?.numero, conta?.accountNumber, cliente.numeroConta);
+
+    return {
+      id: cliente.id !== undefined && cliente.id !== null ? String(cliente.id) : cpfCliente || numeroConta,
+      cpf: cpfCliente || '-',
+      nome: this.resolverTexto(cliente.nome, conta?.holderName),
+      cidade: this.resolverTexto(cliente.cidade, cliente.endereco?.cidade, 'Nao informado'),
+      estado: this.resolverTexto(cliente.estado, cliente.uf, cliente.endereco?.uf, 'Nao informado'),
+      saldo: this.resolverNumero(conta?.saldo, conta?.availableBalance, cliente.saldo),
+      limite: this.resolverNumero(conta?.limite, conta?.limit, cliente.limite),
+      numeroConta,
+    };
+  }
+
+  private mapearClienteDetalhado(
+    cliente: ClienteConsulta,
+    conta: ContaConsulta | null,
+    gerentes: Gerente[],
+  ): ClienteDetalhado {
+    const cpfGerente = this.resolverCpfGerente(
+      conta,
+      cliente.cpfGerente,
+      cliente.cpfGerenteResponsavel,
+    );
+    const nomeGerente = this.resolverNomeGerente(cpfGerente, gerentes, conta, cliente.nomeGerente);
+
+    return {
+      nome: this.resolverTexto(cliente.nome),
+      cpf: this.normalizarDocumento(cliente.cpf) || '-',
+      email: this.resolverTexto(cliente.email),
+      celular: this.resolverTexto(cliente.celular, cliente.telefone, ''),
+      endereco: {
+        cep: this.resolverTexto(cliente.cep, cliente.endereco?.cep, ''),
+        logradouro: this.resolverTexto(cliente.logradouro, cliente.endereco?.logradouro, ''),
+        numero: this.resolverTexto(cliente.numero, cliente.endereco?.numero, ''),
+        complemento: this.resolverTexto(cliente.complemento, cliente.endereco?.complemento, ''),
+        bairro: this.resolverTexto(cliente.bairro, cliente.endereco?.bairro, ''),
+        cidade: this.resolverTexto(cliente.cidade, cliente.endereco?.cidade, ''),
+        uf: this.resolverTexto(cliente.estado, cliente.uf, cliente.endereco?.uf, ''),
+      },
+      salario: this.resolverNumero(cliente.salario),
+      saldo: this.resolverNumero(conta?.saldo, conta?.availableBalance, cliente.saldo),
+      limite: this.resolverNumero(conta?.limite, conta?.limit, cliente.limite),
+      gerente: nomeGerente === '-' ? undefined : nomeGerente,
+      managerDocument: cpfGerente || undefined,
+    };
+  }
+
+  private mapearMelhorCliente(
+    cliente: ClienteConsulta,
+    conta: ContaConsulta | undefined,
+  ): InformacoesMelhorCliente {
+    return {
+      nome: this.resolverTexto(cliente.nome, conta?.holderName, 'Nao informado'),
+      cpf: this.normalizarDocumento(cliente.cpf) || this.resolverCpfCliente(conta) || '-',
+      cidade: this.resolverTexto(cliente.cidade, cliente.endereco?.cidade, 'Nao informado'),
+      estado: this.resolverTexto(cliente.estado, cliente.uf, cliente.endereco?.uf, 'Nao informado'),
+      saldo: this.resolverNumero(conta?.saldo, conta?.availableBalance, cliente.saldo),
+    };
+  }
+
+  private resolverNomeGerente(
+    cpfGerente: string,
+    gerentes: Gerente[],
+    conta?: ContaConsulta | null,
+    nomeGerente?: string,
+  ): string {
+    const gerente = gerentes.find(
+      (item) => this.normalizarDocumento(item.cpf) === cpfGerente,
+    );
+    const nomeConta = this.pareceCpf(conta?.manager) ? undefined : conta?.manager;
+
+    return this.resolverTexto(gerente?.nome, nomeGerente, nomeConta);
+  }
+
+  private resolverCpfCliente(conta?: ContaConsulta | null): string {
+    return this.normalizarDocumento(conta?.cliente || conta?.holderDocument || '');
+  }
+
+  private resolverCpfGerente(
+    conta?: ContaConsulta | null,
+    ...candidatos: Array<string | null | undefined>
+  ): string {
+    const gerenteCompatibilidade = this.pareceCpf(conta?.manager) ? conta?.manager : undefined;
+    const valores = [
+      conta?.gerente,
+      conta?.managerDocument,
+      gerenteCompatibilidade,
+      ...candidatos,
+    ];
+
+    for (const valor of valores) {
+      const documento = this.normalizarDocumento(valor || '');
+
+      if (documento) {
+        return documento;
+      }
+    }
+
+    return '';
+  }
+
+  private resolverTexto(
+    ...valores: Array<string | number | null | undefined>
+  ): string {
+    for (const valor of valores) {
+      if (valor === null || valor === undefined) {
+        continue;
+      }
+
+      const texto = String(valor).trim();
+
+      if (texto) {
+        return texto;
+      }
+    }
+
+    return '-';
+  }
+
+  private resolverNumero(...valores: ValorNumerico[]): number {
+    for (const valor of valores) {
+      const numero = this.converterNumero(valor);
+
+      if (numero !== null) {
+        return this.arredondar(numero);
+      }
+    }
+
+    return 0;
+  }
+
+  private converterNumero(valor: ValorNumerico): number | null {
+    if (typeof valor === 'number' && Number.isFinite(valor)) {
+      return valor;
+    }
+
+    if (typeof valor === 'string' && valor.trim()) {
+      const numero = Number(valor.replace(/\./g, '').replace(',', '.'));
+
+      if (Number.isFinite(numero)) {
+        return numero;
+      }
+    }
+
+    return null;
+  }
+
+  private temValorNumerico(valor: ValorNumerico): boolean {
+    return this.converterNumero(valor) !== null;
+  }
+
+  private pareceCpf(valor: string | null | undefined): boolean {
+    return this.normalizarDocumento(valor || '').length === 11;
+  }
+
+  private normalizarDocumento(valor: string): string {
+    return valor.replace(/\D/g, '');
+  }
+
+  private arredondar(valor: number): number {
+    return Math.round((valor + Number.EPSILON) * 100) / 100;
+  }
+}

--- a/front-end/src/app/core/services/consultas-gerenciais.service.ts
+++ b/front-end/src/app/core/services/consultas-gerenciais.service.ts
@@ -96,22 +96,14 @@ export class ConsultasGerenciaisService {
     }
 
     return forkJoin({
-      clientes: this.clienteService.listarTodosClientes(),
+      cliente: this.clienteService.buscarClientePorCpf(cpfNormalizado),
       gerentes: this.gerentesService.listar(),
     }).pipe(
-      switchMap(({ clientes, gerentes }) => {
-        const cliente = clientes.find(
-          (item) => this.normalizarDocumento(item.cpf) === cpfNormalizado,
-        );
-
-        if (!cliente) {
-          return of(null);
-        }
-
-        return this.contaService.buscarPerfilContaPorCpf(cpfNormalizado).pipe(
+      switchMap(({ cliente, gerentes }) =>
+        this.contaService.buscarPerfilContaPorCpf(cpfNormalizado).pipe(
           map((conta) => this.mapearClienteDetalhado(cliente, conta, gerentes)),
-        );
-      }),
+        ),
+      ),
     );
   }
 

--- a/front-end/src/app/core/services/conta.service.ts
+++ b/front-end/src/app/core/services/conta.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import {
   BehaviorSubject,
   Observable,
@@ -29,6 +29,7 @@ import {
   TransferenciaRequest,
   TransferenciaResponse,
 } from '../../shared/models/conta';
+import { ContaConsulta } from '../../shared/models/consultas-gerenciais';
 import {
   PREFIXO_ARMAZENAMENTO_CONTA_CLIENTE,
   buildScopedStorageKey,
@@ -60,6 +61,57 @@ export class ContaService {
       `${this.apiUrl}/contas/${numeroConta}`,
       this.withBearerAuth(),
     );
+  }
+
+  buscarPerfilContaPorCpf(cpf: string): Observable<ContaConsulta | null> {
+    return this.buscarContaPorCpf(cpf).pipe(
+      switchMap((contaResumida) =>
+        this.buscarConta(contaResumida.numeroConta).pipe(
+          map((perfil) => this.mapearContaConsulta(cpf, contaResumida, perfil)),
+        ),
+      ),
+      catchError((erro: unknown) => {
+        if (erro instanceof HttpErrorResponse && erro.status === 404) {
+          return of(null);
+        }
+
+        return throwError(() => erro);
+      }),
+    );
+  }
+
+  private mapearContaConsulta(
+    cpf: string,
+    contaResumida: ContaPorCpfResponse,
+    perfil: ContaConsulta,
+  ): ContaConsulta {
+    const cpfNormalizado = this.normalizarDocumento(cpf);
+    const gerenteCompatibilidade =
+      perfil.manager && this.normalizarDocumento(perfil.manager).length === 11
+        ? perfil.manager
+        : '';
+
+    return {
+      ...contaResumida,
+      ...perfil,
+      cliente: perfil.cliente || perfil.holderDocument || perfil.cpf || cpfNormalizado,
+      numero: perfil.numero || perfil.accountNumber || perfil.numeroConta || contaResumida.numeroConta,
+      saldo: perfil.saldo ?? perfil.availableBalance ?? perfil.saldoDisponivel ?? contaResumida.saldoDisponivel,
+      limite: perfil.limite ?? perfil.limit ?? contaResumida.limite,
+      gerente:
+        perfil.gerente ||
+        perfil.managerDocument ||
+        contaResumida.gerente ||
+        contaResumida.managerDocument ||
+        gerenteCompatibilidade,
+      holderDocument: perfil.holderDocument || perfil.cpf || cpfNormalizado,
+      accountNumber: perfil.accountNumber || perfil.numeroConta || contaResumida.numeroConta,
+      availableBalance:
+        perfil.availableBalance ?? perfil.saldoDisponivel ?? contaResumida.saldoDisponivel,
+      limit: perfil.limit ?? perfil.limite ?? contaResumida.limite,
+      managerDocument: perfil.managerDocument || contaResumida.managerDocument,
+      manager: perfil.manager || contaResumida.manager,
+    };
   }
 
   depositar(numeroConta: string, valor: number): Observable<OperacaoResponse> {

--- a/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.ts
+++ b/front-end/src/app/features/admin/pages/relatorio-clientes/relatorio-clientes.ts
@@ -9,54 +9,39 @@ import {
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { forkJoin } from 'rxjs';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
-import { API_URL } from '../../../../core/configs/api.token';
-import { ClienteService } from '../../../../core/services/cliente.service';
 
-// Interface para tipar os dados da nossa tabela
-export interface RelatorioCliente {
-  cpfCliente: string;
-  nomeCliente: string;
-  emailCliente: string;
-  salario: number;
-  numeroConta: string;
-  saldo: number;
-  limite: number;
-  cpfGerente: string;
-  nomeGerente: string;
-}
+import { ConsultasGerenciaisService } from '../../../../core/services/consultas-gerenciais.service';
+import { RelatorioCliente } from '../../../../shared/models/consultas-gerenciais';
 
 @Component({
   selector: 'app-relatorio-clientes',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatSortModule,
-    MatTableModule
-  ],
+  imports: [CommonModule, MatSortModule, MatTableModule],
   templateUrl: './relatorio-clientes.html',
   styleUrl: './relatorio-clientes.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RelatorioClientesComponent implements OnInit, AfterViewInit {
   private readonly destroyRef = inject(DestroyRef);
-  private readonly http = inject(HttpClient);
-  private readonly apiUrl = inject(API_URL);
-  private readonly clienteService = inject(ClienteService);
+  private readonly consultasGerenciaisService = inject(ConsultasGerenciaisService);
 
   @ViewChild(MatSort) private ordenador!: MatSort;
 
-  // As 9 colunas exigidas pelo protótipo
   readonly colunasExibidas = [
-    'cpfCliente', 'nomeCliente', 'emailCliente', 'salario', 
-    'numeroConta', 'saldo', 'limite', 'cpfGerente', 'nomeGerente'
+    'cpfCliente',
+    'nomeCliente',
+    'emailCliente',
+    'salario',
+    'numeroConta',
+    'saldo',
+    'limite',
+    'cpfGerente',
+    'nomeGerente',
   ];
-  
-  // Controle de estado da tela usando Signals
+
   readonly carregando = signal(true);
   readonly mensagemErro = signal('');
   readonly fonteDados = new MatTableDataSource<RelatorioCliente>([]);
@@ -69,11 +54,13 @@ export class RelatorioClientesComponent implements OnInit, AfterViewInit {
     this.fonteDados.sort = this.ordenador;
   }
 
-  // Reaproveitado a máscara de CPF
   formatarCpf(cpf: string): string {
     if (!cpf || cpf === '-') return '-';
+
     const cpfNormalizado = cpf.replace(/\D/g, '');
+
     if (cpfNormalizado.length !== 11) return cpf;
+
     return cpfNormalizado.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
   }
 
@@ -81,43 +68,18 @@ export class RelatorioClientesComponent implements OnInit, AfterViewInit {
     this.carregando.set(true);
     this.mensagemErro.set('');
 
-    // Dispara as 3 requisições ao mesmo tempo
-    forkJoin({
-      clientes: this.clienteService.listarRelatorioClientes(),
-      contas: this.http.get<any[]>(`${this.apiUrl}/contas`),
-      gerentes: this.http.get<any[]>(`${this.apiUrl}/gerentes`)
-    })
-    .pipe(takeUntilDestroyed(this.destroyRef))
-    .subscribe({
-      next: (res) => {
-        // JOIN MANUAL exigido pela R16
-        const dadosMapeados = res.clientes.map(cliente => {
-          // Busca a conta que pertence a este cliente
-          const conta = res.contas.find(c => c.holderDocument === cliente.cpf);
-          
-          return {
-            cpfCliente: cliente.cpf,
-            nomeCliente: cliente.nome,
-            emailCliente: cliente.email,
-            salario: cliente.salario || 0,
-            numeroConta: conta ? conta.accountNumber : '-',
-            saldo: conta ? conta.availableBalance : 0,
-            limite: conta ? conta.limit : 0,
-            cpfGerente: conta && conta.managerDocument ? conta.managerDocument : '-',
-            nomeGerente: conta && conta.manager ? conta.manager : '-'
-          };
-        });
-
-        // Ordena a lista pelo nome do cliente em ordem alfabética
-        dadosMapeados.sort((a, b) => a.nomeCliente.localeCompare(b.nomeCliente));
-
-        this.fonteDados.data = dadosMapeados;
-        this.carregando.set(false);
-      },
-      error: () => {
-        this.mensagemErro.set('Não foi possível carregar os dados do relatório.');
-        this.carregando.set(false);
-      }
-    });
+    this.consultasGerenciaisService
+      .listarRelatorioClientes()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (dadosMapeados) => {
+          this.fonteDados.data = dadosMapeados;
+          this.carregando.set(false);
+        },
+        error: () => {
+          this.mensagemErro.set('Nao foi possivel carregar os dados do relatorio.');
+          this.carregando.set(false);
+        },
+      });
   }
 }

--- a/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.ts
+++ b/front-end/src/app/features/manager/pages/consultar-clientes/consultar-clientes.ts
@@ -1,49 +1,38 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { forkJoin } from 'rxjs';
-import { AuthService } from '../../../../core/auth/services/auth.service';
-import { formatCpf } from '../../../../shared/utils/formatters';
-import { API_URL } from '../../../../core/configs/api.token';
-import { ClienteService } from '../../../../core/services/cliente.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-export interface Cliente {
-  id: string;
-  cpf: string;
-  nome: string;
-  cidade: string;
-  estado: string;
-  saldo: number;
-  limite: number;
-  numeroConta?: string;
-}
+import { AuthService } from '../../../../core/auth/services/auth.service';
+import { ConsultasGerenciaisService } from '../../../../core/services/consultas-gerenciais.service';
+import { ClienteCarteira } from '../../../../shared/models/consultas-gerenciais';
+import { formatCpf } from '../../../../shared/utils/formatters';
+
+export type Cliente = ClienteCarteira;
 
 @Component({
   selector: 'app-consultar-clientes',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterModule, HttpClientModule],
+  imports: [CommonModule, FormsModule, RouterModule],
   templateUrl: './consultar-clientes.html',
-  styleUrls: ['./consultar-clientes.css']
+  styleUrls: ['./consultar-clientes.css'],
 })
 export class ConsultarClientesComponent implements OnInit {
-  private readonly apiUrl = inject(API_URL);
-  private readonly clienteService = inject(ClienteService);
-  
-  tipoFiltro: 'nome' | 'cpf' = 'nome';
-  termoBusca: string = '';
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly authService = inject(AuthService);
+  private readonly consultasGerenciaisService = inject(ConsultasGerenciaisService);
 
-  // Configurações de Paginação
-  paginaAtual: number = 1;
-  itensPorPagina: number = 5;
+  tipoFiltro: 'nome' | 'cpf' = 'nome';
+  termoBusca = '';
+
+  paginaAtual = 1;
+  itensPorPagina = 5;
   clientesPaginados: Cliente[] = [];
 
   clientes: Cliente[] = [];
   clientesExibidos: Cliente[] = [];
-  carregando: boolean = true;
-
-  constructor(private http: HttpClient, private authService: AuthService) {}
+  carregando = true;
 
   ngOnInit(): void {
     this.carregarClientesDaAPI();
@@ -51,63 +40,46 @@ export class ConsultarClientesComponent implements OnInit {
 
   formatarCpf(cpf: string): string {
     if (!cpf || cpf === '-') return '-';
+
     const cpfNormalizado = cpf.replace(/\D/g, '');
+
     if (cpfNormalizado.length !== 11) return cpf;
+
     return cpfNormalizado.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
   }
 
   carregarClientesDaAPI(): void {
     this.carregando = true;
-    
-    // Pega o CPF do gerente logado
+
     const gerenteLogado = this.authService.currentUserValue;
     const cpfGerenteLogado = gerenteLogado?.cpf ? gerenteLogado.cpf.replace(/\D/g, '') : '';
 
-    forkJoin({
-      clientes: this.clienteService.listarTodosClientes(),
-      contas: this.http.get<any[]>(`${this.apiUrl}/contas`)
-    }).subscribe({
-      next: (res) => {
-        const clientesDoGerente: Cliente[] = [];
+    if (!cpfGerenteLogado) {
+      this.clientes = [];
+      this.clientesExibidos = [];
+      this.atualizarPaginacao();
+      this.carregando = false;
+      return;
+    }
 
-        res.clientes.forEach(cliente => {
-          const cpfClienteLimpo = cliente.cpf ? cliente.cpf.replace(/\D/g, '') : '';
-          
-          const conta = res.contas.find(c => {
-            const holderCpfLimpo = c.holderDocument ? c.holderDocument.replace(/\D/g, '') : '';
-            return holderCpfLimpo === cpfClienteLimpo;
-          });
-
-          // Filtra: Só adiciona se o managerDocument da conta for igual ao CPF do gerente logado
-          if (conta && conta.managerDocument) {
-            const managerCpfLimpo = conta.managerDocument.replace(/\D/g, '');
-            
-            if (managerCpfLimpo === cpfGerenteLogado) {
-              clientesDoGerente.push({
-                id: String(cliente.id || Math.random()),
-                cpf: cliente.cpf,
-                nome: cliente.nome,
-                cidade: cliente.cidade || cliente.endereco?.cidade || '-',
-                estado: cliente.estado || cliente.uf || cliente.endereco?.uf || '-',
-                saldo: conta.availableBalance || 0,
-                limite: conta.limit || 0,
-                numeroConta: conta.accountNumber || '-'
-              });
-            }
-          }
-        });
-
-        this.clientes = clientesDoGerente;
-        this.ordenarClientesPorNome();
-        this.clientesExibidos = [...this.clientes];
-        this.atualizarPaginacao();
-        this.carregando = false;
-      },
-      error: (erro) => {
-        console.error('Erro ao buscar clientes da API:', erro);
-        this.carregando = false;
-      }
-    });
+    this.consultasGerenciaisService
+      .listarClientesDoGerente(cpfGerenteLogado)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (clientes) => {
+          this.clientes = clientes;
+          this.ordenarClientesPorNome();
+          this.clientesExibidos = [...this.clientes];
+          this.atualizarPaginacao();
+          this.carregando = false;
+        },
+        error: () => {
+          this.clientes = [];
+          this.clientesExibidos = [];
+          this.atualizarPaginacao();
+          this.carregando = false;
+        },
+      });
   }
 
   get totalPaginas(): number {
@@ -115,7 +87,7 @@ export class ConsultarClientesComponent implements OnInit {
   }
 
   ordenarClientesPorNome(): void {
-    this.clientes.sort((a, b) => a.nome.localeCompare(b.nome));
+    this.clientes.sort((atual, proximo) => atual.nome.localeCompare(proximo.nome, 'pt-BR'));
   }
 
   filtrarClientes(): void {
@@ -124,23 +96,22 @@ export class ConsultarClientesComponent implements OnInit {
     } else {
       const termo = this.termoBusca.toLowerCase().trim();
 
-      this.clientesExibidos = this.clientes.filter(cliente => {
+      this.clientesExibidos = this.clientes.filter((cliente) => {
         if (this.tipoFiltro === 'nome') {
           return cliente.nome.toLowerCase().includes(termo);
-        } else {
-          const cpfLimpo = cliente.cpf.replace(/\D/g, '');
-          const termoLimpo = termo.replace(/\D/g, '');
-          return cpfLimpo.includes(termoLimpo) || cliente.cpf.includes(termo);
         }
+
+        const cpfLimpo = cliente.cpf.replace(/\D/g, '');
+        const termoLimpo = termo.replace(/\D/g, '');
+
+        return cpfLimpo.includes(termoLimpo) || cliente.cpf.includes(termo);
       });
     }
-    
-    // Sempre que filtrar, volta para a primeira página
+
     this.paginaAtual = 1;
     this.atualizarPaginacao();
   }
 
-  // --- LÓGICA DE PAGINAÇÃO ---
   atualizarPaginacao(): void {
     const indiceInicio = (this.paginaAtual - 1) * this.itensPorPagina;
     const indiceFim = indiceInicio + this.itensPorPagina;
@@ -166,14 +137,14 @@ export class ConsultarClientesComponent implements OnInit {
     let valor = input.value;
 
     if (this.tipoFiltro === 'cpf') {
-      valor = formatCpf(valor); // Olha que código elegante e limpo!
+      valor = formatCpf(valor);
     } else if (this.tipoFiltro === 'nome') {
-      valor = valor.replace(/\d/g, ''); 
+      valor = valor.replace(/\d/g, '');
     }
 
     this.termoBusca = valor;
     input.value = valor;
-    
+
     this.filtrarClientes();
   }
 
@@ -181,5 +152,4 @@ export class ConsultarClientesComponent implements OnInit {
     this.termoBusca = '';
     this.filtrarClientes();
   }
-
 }

--- a/front-end/src/app/features/manager/services/detalhe-cliente.service.ts
+++ b/front-end/src/app/features/manager/services/detalhe-cliente.service.ts
@@ -1,86 +1,18 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable, forkJoin, map } from 'rxjs';
-import { API_URL } from '../../../core/configs/api.token';
-import { BankAccount } from '../../../shared/models/bank-account';
-import { ClienteService } from '../../../core/services/cliente.service';
-import { DadosClienteResponse } from '../../../shared/models/cliente.models';
+import { Observable } from 'rxjs';
 
-export interface ClienteDetalhado {
-  nome: string;
-  cpf: string;
-  email: string;
-  celular: string;
-  endereco: {
-    cep: string;
-    logradouro: string;
-    numero: string;
-    complemento?: string;
-    bairro: string;
-    cidade: string;
-    uf: string;
-  };
-  salario: string;
-  saldo: string;
-  limite: string;
-  managerDocument?: string;
-}
+import { ConsultasGerenciaisService } from '../../../core/services/consultas-gerenciais.service';
+import { ClienteDetalhado } from '../../../shared/models/consultas-gerenciais';
+
+export type { ClienteDetalhado } from '../../../shared/models/consultas-gerenciais';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DetalheClienteService {
-  private readonly http = inject(HttpClient);
-  private readonly apiUrl = inject(API_URL);
-  private readonly clienteService = inject(ClienteService);
+  private readonly consultasGerenciaisService = inject(ConsultasGerenciaisService);
 
   obterClienteDetalhadoPorCpf(cpf: string): Observable<ClienteDetalhado | null> {
-    const cpfLimpo = cpf.replace(/\D/g, '');
-
-    return forkJoin({
-      clientes: this.clienteService.listarTodosClientes(),
-      contas: this.http.get<BankAccount[]>(`${this.apiUrl}/contas`),
-    }).pipe(
-      map(({ clientes, contas }) => {
-        const cliente = clientes.find((clienteAtual) => clienteAtual.cpf === cpfLimpo);
-
-        if (!cliente) {
-          return null;
-        }
-
-        const conta = contas.find((contaAtual) => contaAtual.holderDocument === cpfLimpo);
-
-        return {
-          nome: cliente.nome,
-          cpf: cliente.cpf,
-          email: cliente.email,
-          celular: cliente.celular || cliente.telefone || '',
-          endereco: this.obterEndereco(cliente),
-          salario: this.formatarMoeda(cliente.salario || 0),
-          saldo: this.formatarMoeda(conta?.availableBalance || 0),
-          limite: this.formatarMoeda(conta?.limit || 0),
-          managerDocument: (conta as any)?.managerDocument || (conta as any)?.manager
-        };
-      }),
-    );
-  }
-
-  private formatarMoeda(valor: number): string {
-    return valor.toLocaleString('pt-BR', {
-      style: 'currency',
-      currency: 'BRL',
-    });
-  }
-
-  private obterEndereco(cliente: DadosClienteResponse): ClienteDetalhado['endereco'] {
-    return {
-      cep: cliente.cep || cliente.endereco?.cep || '',
-      logradouro: cliente.logradouro || cliente.endereco?.logradouro || '',
-      numero: cliente.numero || cliente.endereco?.numero || '',
-      complemento: cliente.complemento || cliente.endereco?.complemento || '',
-      bairro: cliente.bairro || cliente.endereco?.bairro || '',
-      cidade: cliente.cidade || cliente.endereco?.cidade || '',
-      uf: cliente.estado || cliente.uf || cliente.endereco?.uf || '',
-    };
+    return this.consultasGerenciaisService.obterClienteDetalhadoPorCpf(cpf);
   }
 }

--- a/front-end/src/app/features/manager/services/melhores-clientes.service.ts
+++ b/front-end/src/app/features/manager/services/melhores-clientes.service.ts
@@ -1,64 +1,22 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable, forkJoin, map } from 'rxjs';
+import { Observable } from 'rxjs';
 
-import { API_URL } from '../../../core/configs/api.token';
-import { ClienteService } from '../../../core/services/cliente.service';
-import { BankAccount } from '../../../shared/models/bank-account';
-import { ClienteResponse } from '../../../shared/models/cliente.models';
+import { AuthService } from '../../../core/auth/services/auth.service';
+import { ConsultasGerenciaisService } from '../../../core/services/consultas-gerenciais.service';
+import { InformacoesMelhorCliente } from '../../../shared/models/consultas-gerenciais';
 
-export interface InformacoesMelhorCliente {
-  nome: string;
-  cpf: string;
-  cidade: string;
-  estado: string;
-  saldo: number;
-}
+export type { InformacoesMelhorCliente } from '../../../shared/models/consultas-gerenciais';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MelhoresClientesService {
-  private readonly http = inject(HttpClient);
-  private readonly apiUrl = inject(API_URL);
-  private readonly clienteService = inject(ClienteService);
+  private readonly consultasGerenciaisService = inject(ConsultasGerenciaisService);
+  private readonly authService = inject(AuthService);
 
   obter3MelhoresClientes(): Observable<InformacoesMelhorCliente[]> {
-    return forkJoin({
-      contas: this.http.get<BankAccount[]>(`${this.apiUrl}/contas`),
-      clientes: this.clienteService.listarMelhoresClientes(),
-    }).pipe(
-      map(({ contas, clientes }) => {
-        const melhoresContas = contas
-          .sort(
-            (contaAtual, proximaConta) =>
-              (proximaConta.availableBalance || 0) -
-              (contaAtual.availableBalance || 0),
-          )
-          .slice(0, 3);
-
-        return melhoresContas.map((conta) => {
-          const cliente = clientes.find(
-            (clienteAtual) => clienteAtual.cpf === conta.holderDocument,
-          );
-
-          return {
-            nome: cliente?.nome || conta.holderName,
-            cpf: conta.holderDocument,
-            cidade: this.resolverCidade(cliente),
-            estado: this.resolverEstado(cliente),
-            saldo: conta.availableBalance || 0,
-          };
-        });
-      }),
+    return this.consultasGerenciaisService.listarMelhoresClientes(
+      this.authService.currentUserValue?.cpf,
     );
-  }
-
-  private resolverCidade(cliente?: ClienteResponse): string {
-    return cliente?.cidade || cliente?.endereco?.cidade || 'Nao informado';
-  }
-
-  private resolverEstado(cliente?: ClienteResponse): string {
-    return cliente?.estado || cliente?.uf || cliente?.endereco?.uf || 'Nao informado';
   }
 }

--- a/front-end/src/app/shared/models/consultas-gerenciais.ts
+++ b/front-end/src/app/shared/models/consultas-gerenciais.ts
@@ -1,0 +1,68 @@
+import { ContaPerfilResponse } from './conta';
+
+export interface ContaConsulta extends Partial<ContaPerfilResponse> {
+  cpf?: string;
+  numeroConta?: string;
+  saldoDisponivel?: number;
+  holderDocument?: string;
+  accountNumber?: string;
+  availableBalance?: number;
+  limit?: number;
+  managerDocument?: string;
+  manager?: string;
+  holderName?: string;
+}
+
+export interface RelatorioCliente {
+  cpfCliente: string;
+  nomeCliente: string;
+  emailCliente: string;
+  salario: number;
+  numeroConta: string;
+  saldo: number;
+  limite: number;
+  cpfGerente: string;
+  nomeGerente: string;
+}
+
+export interface ClienteCarteira {
+  id: string;
+  cpf: string;
+  nome: string;
+  cidade: string;
+  estado: string;
+  saldo: number;
+  limite: number;
+  numeroConta?: string;
+}
+
+export interface EnderecoClienteDetalhado {
+  cep: string;
+  logradouro: string;
+  numero: string;
+  complemento?: string;
+  bairro: string;
+  cidade: string;
+  uf: string;
+}
+
+export interface ClienteDetalhado {
+  nome: string;
+  cpf: string;
+  email: string;
+  celular: string;
+  endereco: EnderecoClienteDetalhado;
+  salario: number;
+  saldo: number;
+  limite: number;
+  gerente?: string;
+  managerDocument?: string;
+}
+
+export interface InformacoesMelhorCliente {
+  nome: string;
+  cpf: string;
+  cidade: string;
+  estado: string;
+  saldo: number;
+}

--- a/front-end/src/app/shared/models/conta.ts
+++ b/front-end/src/app/shared/models/conta.ts
@@ -42,6 +42,10 @@ export interface ExtratoResponse {
 export interface ContaPorCpfResponse {
   numeroConta: string;
   saldoDisponivel: number;
+  limite?: number;
+  gerente?: string;
+  manager?: string;
+  managerDocument?: string;
 }
 
 export interface ContaPerfilResponse {


### PR DESCRIPTION
﻿## Descrição

Centraliza as consultas gerenciais de clientes, contas e gerentes em um serviço compartilhado para evitar composições locais duplicadas nas telas de relatório administrativo e consultas do gerente.

Também foi ajustado o contrato do `ms-cliente` para retornar `salario` somente nos fluxos autorizados, mantendo o relatório administrativo funcionando com o backend real sem expor o dado na listagem genérica de clientes.

## Tipo de Mudança

- **FEAT**: Nova funcionalidade.
- **FIX**: Correção de bug.

## O que mudou

- Cria `ConsultasGerenciaisService` e modelos compartilhados para montar dados de clientes, contas e gerentes.
- Reaproveita `ClienteService`, `ContaService` e `GerentesService` nas telas afetadas.
- Ajusta o relatório administrativo para exibir salário, conta, saldo, limite e gerente com associação por CPF normalizado.
- Filtra a carteira e os melhores clientes pelo gerente autenticado.
- Mantém o bloqueio de detalhe quando o gerente tenta consultar cliente de outra carteira.
- Restringe `salario` no `ClienteResponseDTO`: a listagem genérica não carrega o valor, e o relatório administrativo usa o filtro próprio com validação de perfil.

## Alinhamento com a PR #121

Antes de abrir esta PR, a PR #121 foi revisada para alinhar os dois trabalhos e evitar sobreposição desnecessária.

O único arquivo em comum entre esta branch e a #121 é:

- `back-end/cliente/src/main/java/com/bantads/cliente/dto/ClienteResponseDTO.java`

Nesta PR, o DTO passa a retornar `salario`. Na PR #121, o mesmo DTO passa a retornar `cpfGerenteResponsavel`.

Se a #121 for mergeada antes, o conflito esperado nesse arquivo deve ser resolvido mantendo os dois campos e os dois mapeamentos:

- manter `salario` para o relatório administrativo desta PR;
- manter `cpfGerenteResponsavel` para o dashboard administrativo da #121.

Esta PR não altera os endpoints de `conta` nem o serviço `gerentes-dashboard.service.ts` trabalhados na #121.

## Guia de Testes

**Como reproduzir com o compose da branch:**
1. Na branch desta PR, subir a aplicação integrada:

   ```bash
   docker compose up -d --build
   ```

2. Acessar o frontend em `http://localhost:4200`.
3. Autenticar com usuários reais do seed local.
4. Validar os fluxos administrativos e gerenciais no navegador usando o frontend do compose, que aponta para o API Gateway em `http://localhost:8080`.
5. Rodar o build do frontend.
6. Rodar os testes do `back-end/cliente`.

O serviço `frontend` do compose usa o alvo `dev` do `front-end/Dockerfile` e monta `./front-end:/app`, então o código executado deve ser o código da branch da PR.

**Comandos executados:**

- `npm.cmd run build`
- `mvnw.cmd test` em `back-end/cliente`, com `JAVA_HOME` ajustado para o JDK 21 instalado localmente.

**Validação manual com backend real:**

- Relatório administrativo exibindo clientes com salário, conta, saldo, limite e gerente.
- Carteira do gerente exibindo apenas clientes vinculados ao gerente autenticado.
- Busca por nome e CPF na carteira do gerente.
- Detalhe do cliente permitido para cliente da carteira.
- Detalhe do cliente bloqueado para cliente de outro gerente.
- Melhores clientes filtrados pela carteira do gerente autenticado.

Não foi usado mock local na validação manual.

## Screenshots
<img width="1650" height="820" alt="build-frontend" src="https://github.com/user-attachments/assets/cb423bc1-4b52-4738-ad57-cdc8f15d0b45" />

build do frontend.

<img width="1650" height="820" alt="teste-backend-cliente" src="https://github.com/user-attachments/assets/532fbee1-b2f7-407e-9672-2b121e75f383" />

`mvnw.cmd test` do `back-end/cliente`.

<img width="1650" height="820" alt="backend-cliente-terminal" src="https://github.com/user-attachments/assets/1e43e5da-b441-461f-a4ad-dd33d2ba74ed" />

terminal com o `ms-cliente` rodando corretamente contra PostgreSQL real.

<img width="1440" height="900" alt="fluxo-admin-relatorio-clientes" src="https://github.com/user-attachments/assets/c18eac95-cf41-43b0-8756-426c4e799f98" />

relatório administrativo com salário, conta, saldo, limite e gerente.

<img width="1440" height="900" alt="fluxo-gerente-consultar-clientes" src="https://github.com/user-attachments/assets/daf988cc-97a9-4972-b885-394be9869537" />

carteira do gerente filtrada pelo gerente autenticado.

<img width="1440" height="900" alt="fluxo-gerente-busca-clientes" src="https://github.com/user-attachments/assets/151a5ff4-f8fa-4e7e-b33b-ceb42a4abb6e" />

busca por nome na carteira do gerente.

<img width="1440" height="986" alt="fluxo-gerente-detalhe-cliente" src="https://github.com/user-attachments/assets/51888898-73c9-45b7-84ac-f03255ddb631" />

detalhe permitido para cliente da carteira.

<img width="1440" height="980" alt="fluxo-gerente-acesso-negado" src="https://github.com/user-attachments/assets/cb8c3079-18a5-4e5d-bd5a-a18cab9a4409" />

bloqueio de cliente de outro gerente.

<img width="1440" height="900" alt="fluxo-gerente-melhores-clientes" src="https://github.com/user-attachments/assets/08eca8b2-2c34-4b7f-918d-3fe7ea737f31" />

melhores clientes filtrados pela carteira do gerente autenticado.



