### PR TITLE
fix: ajuste fixo para a imagem da tela não sobrescrever o nome

### DIFF
--- a/front-end/src/app/features/client/pages/pagina-inicial/pagina-inicial.css
+++ b/front-end/src/app/features/client/pages/pagina-inicial/pagina-inicial.css
@@ -27,6 +27,7 @@ main {
   position: absolute;
   right: -80px;
   top: -26px;
+  width:630px;
 }
 
 .menu-cards {


### PR DESCRIPTION
Neste PR, realizei a correção visual na tela inicial onde a imagem da marca acabava sobrepondo o nome do cliente. Além da correção visual, realizei a validação dos fluxos de Autenticação e Cadastro. Testei o login com um usuário pré-existente (buscando e exibindo as informações e o saldo corretamente direto do banco de dados de leitura) e validei a criação de um novo cliente, confirmando que a persistência de dados está seguindo o padrão correto da arquitetura.

🛠 Tipo de Mudança
[x] 🐛 FIX: Correção de bug.
[x] 🧪 TEST: Adição ou correção de testes.

🧪 Guia de Testes
Como reproduzir:

Suba os contêineres do back-end
Acesse a aplicação em http://localhost:4200 e vá para a tela de Login.
Teste de Login: Insira as credenciais de um cliente pré-cadastrado (ex: cli1@bantads.com.br / senha: tads). Confirme o redirecionamento e a busca correta do saldo.
Teste de Layout: Verifique a tela inicial e confirme que a imagem não está sobrepondo nomes (você pode inspecionar e injetar um nome muito longo para forçar o teste).
Teste de Autocadastro: Faça logout, clique para criar uma nova conta e passe pelo fluxo de cadastro de um novo cliente. Verifique os logs do back-end (Gateway e Conta) para confirmar o fluxo.

Resultado esperado:
A imagem da marca brand-illustration.svg deve se manter contida em seu espaço, sem quebrar o layout do texto de boas-vindas. O sistema deve validar as credenciais, gerar o token e exibir o saldo correto puxado da view de leitura do banco de dados. O cadastro de um novo usuário deve ocorrer sem erros e refletir no banco de dados.

📸 Screenshots
<img width="1290" height="594" alt="Captura de tela 2026-06-01 140505" src="https://github.com/user-attachments/assets/b7ff4fe1-43e4-4a76-9537-071af8e9d15c" />
<img width="765" height="229" alt="Captura de tela 2026-06-01 135116" src="https://github.com/user-attachments/assets/d3fcae44-9118-4113-a09d-2b7dbfb74398" />
<img width="577" height="145" alt="Captura de tela 2026-06-01 135257" src="https://github.com/user-attachments/assets/cbb96d98-f28d-403a-a790-6a3548356155" />
<img width="697" height="462" alt="Captura de tela 2026-06-01 135350" src="https://github.com/user-attachments/assets/b7685a95-7780-42d4-9d18-266d51a2e782" />


