### PR TITLE
fix: ajuste erro para modal de sucesso

### DIFF
--- a/front-end/src/app/core/services/gerentes.service.ts
+++ b/front-end/src/app/core/services/gerentes.service.ts
@@ -73,10 +73,8 @@ export class GerentesService {
       .pipe(map((gerente) => this.mapearGerente(gerente)));
   }
 
-  remover(cpf: string): Observable<Gerente> {
-    return this.http
-      .delete<DadoGerente>(`${this.apiUrl}/gerentes/${cpf}`)
-      .pipe(map((gerente) => this.mapearGerente(gerente)));
+  remover(cpf: string): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/gerentes/${cpf}`, { responseType: 'text' });
   }
 
   private criarParametrosListagem(numero?: number): HttpParams | Error {


### PR DESCRIPTION
## 📝 Descrição
validação ponta a ponta de todos os fluxos do perfil Administrador.
O que foi testado e validado no Back-end:
- Login de Administrador: Autenticação via Gateway com redirecionamento e permissões corretas
- Saga de Inserção de Gerente (R12): Validado o fluxo assíncrono onde o ms-gerente insere o funcionário e orquestra a criação de credenciais de acesso no ms-auth via RabbitMQ.
- Edição de Gerente (R20): Alteração de dados cadastrais funcionando e refletindo no banco de dados.
- Saga de Remoção de Gerente (R18): Validada a regra de negócio crítica de balanceamento de carga. Ao excluir um gerente com clientes vinculados, o ms-conta transferiu as contas "órfãs" para o gerente com o menor número de clientes, e o ms-auth revogou o acesso do gerente excluído, garantindo a consistência eventual.
- O que foi corrigido:
Durante o teste da exclusão, o Angular exibia um falso-positivo de "Erro ao excluir", apesar de o back-end processar a remoção com sucesso.
## 🛠 Tipo de Mudança
- 🐛 **FIX**: Correção de bug.
- 🧪 **TEST**: Adição ou correção de testes.

## 🧪 Guia de Testes
**Como reproduzir:**
1. Rodar os contêineres do Back-end (docker compose up -d) e o Angular (ng serve).
2. Realizar login com as credenciais do administrador (ex: adm1@bantads.com.br).
3. Acessar a tela "Ver Gerentes" e inserir um novo gerente de teste. Validar no log do ms-auth se a senha foi gerada.
4. Editar o nome do gerente recém-criado e salvar.
5. Excluir um gerente que já possua clientes vinculados (ex: Geniéve).
6. Acompanhar no painel Network (F12) a requisição DELETE devolvendo 202 Accepted sem o erro visual no Front-end.
7. Acessar o banco de dados via DBeaver e validar nas views do ms-conta que os clientes do gerente excluído foram transferidos automaticamente.

**Resultado esperado:**
O CRUD de gerentes e as orquestrações via RabbitMQ devem ocorrer com sucesso sem disparar erros visuais de conversão de dados no Front-end.
## 📸 Screenshots
<img width="678" height="442" alt="Captura de tela 2026-06-07 195349" src="https://github.com/user-attachments/assets/f8901ace-1d2d-4de1-9e2a-b6110ce95570" />
