### PR TITLE
fix: rejeita cpfs repetidos

### DIFF
--- a/front-end/src/app/shared/utils/cpf-validator.spec.ts
+++ b/front-end/src/app/shared/utils/cpf-validator.spec.ts
@@ -1,0 +1,61 @@
+import { FormControl } from '@angular/forms';
+
+import { CustomValidators } from './cpf-validator';
+
+describe('CustomValidators.useExistingCpfValidator', () => {
+  const validator = CustomValidators.useExistingCpfValidator();
+
+  it('deve aceitar campo vazio para permitir combinacao com required', () => {
+    const resultado = validator(new FormControl(''));
+
+    expect(resultado).toBeNull();
+  });
+
+  it('deve aceitar CPF valido sem mascara', () => {
+    const resultado = validator(new FormControl('52998224725'));
+
+    expect(resultado).toBeNull();
+  });
+
+  it('deve aceitar CPF valido com mascara', () => {
+    const resultado = validator(new FormControl('529.982.247-25'));
+
+    expect(resultado).toBeNull();
+  });
+
+  it('deve rejeitar CPF com quantidade incorreta de digitos', () => {
+    const resultado = validator(new FormControl('529.982.247-2'));
+
+    expect(resultado).toEqual({ cpfInvalido: true });
+  });
+
+  it('deve rejeitar CPF com digito verificador invalido', () => {
+    const resultado = validator(new FormControl('529.982.247-26'));
+
+    expect(resultado).toEqual({ cpfInvalido: true });
+  });
+
+  it('deve rejeitar CPF composto apenas por zeros', () => {
+    const resultado = validator(new FormControl('000.000.000-00'));
+
+    expect(resultado).toEqual({ cpfInvalido: true });
+  });
+
+  it('deve rejeitar CPF com todos os digitos repetidos', () => {
+    const cpfsRepetidos = [
+      '111.111.111-11',
+      '222.222.222-22',
+      '333.333.333-33',
+      '444.444.444-44',
+      '555.555.555-55',
+      '666.666.666-66',
+      '777.777.777-77',
+      '888.888.888-88',
+      '999.999.999-99',
+    ];
+
+    for (const cpf of cpfsRepetidos) {
+      expect(validator(new FormControl(cpf))).toEqual({ cpfInvalido: true });
+    }
+  });
+});

--- a/front-end/src/app/shared/utils/cpf-validator.ts
+++ b/front-end/src/app/shared/utils/cpf-validator.ts
@@ -1,45 +1,46 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 function validarCPF(cpf: string): boolean {
-    let soma : number = 0;  
-    let resto : number;
-    let digitoVerificador1 : number;
-    let digitoVerificador2 : number;
+  const cpfNormalizado = normalizarCPF(cpf);
 
-    cpf = cpf.replaceAll(".", "").replace("-", "");
+  if (!cpfNormalizado || possuiDigitosRepetidos(cpfNormalizado)) {
+    return false;
+  }
 
-    if(cpf.length !== 11) {
-        return false;
-    }
+  const digitoVerificador1 = calcularDigitoVerificador(cpfNormalizado, 9);
+  const digitoVerificador2 = calcularDigitoVerificador(cpfNormalizado, 10);
 
-    //Calculo dos dígito verificador 1
-    soma = 0;
-    for(let i :number = 0; i< 9; i++) {
-        const num : number = parseInt(cpf[i]);
-        const peso : number = 10 - i;
-        soma += num * peso;
-    }
+  return (
+    cpfNormalizado.charAt(9) === digitoVerificador1.toString() &&
+    cpfNormalizado.charAt(10) === digitoVerificador2.toString()
+  );
+}
 
-    resto = soma % 11;
-    digitoVerificador1 = resto < 2 ? 0 : 11 - resto;
+function normalizarCPF(cpf: string): string | null {
+  const cpfNormalizado = cpf.replace(/\D/g, '');
 
-    //Calculo dos dígito verificador 2
-    soma = 0;
-    for(let i :number = 0; i< 10; i++) {
-        const num : number = parseInt(cpf[i]);
-        const peso : number = 11 - i;
-        soma += num * peso;
-    }
+  return cpfNormalizado.length === 11 ? cpfNormalizado : null;
+}
 
-    resto = soma % 11;
-    digitoVerificador2 = resto < 2 ? 0 : 11 - resto;
+function possuiDigitosRepetidos(cpf: string): boolean {
+  return /^(\d)\1{10}$/.test(cpf);
+}
 
-    //Comparação com os dígitos originais
-    if(cpf.charAt(9) !== digitoVerificador1.toString() || cpf.charAt(10) !== digitoVerificador2.toString()) {
-        return false;
-    }
+function calcularDigitoVerificador(
+  cpf: string,
+  quantidadeDigitos: number,
+): number {
+  const soma = cpf
+    .slice(0, quantidadeDigitos)
+    .split('')
+    .reduce((total, digito, indice) => {
+      const peso = quantidadeDigitos + 1 - indice;
+      return total + Number(digito) * peso;
+    }, 0);
 
-return true;
+  const resto = soma % 11;
+
+  return resto < 2 ? 0 : 11 - resto;
 }
 
 export class CustomValidators {
@@ -48,7 +49,7 @@ export class CustomValidators {
       if (!control.value) {
         return null;
       }
-      
+
       const isValid = validarCPF(control.value);
       return isValid ? null : { cpfInvalido: true };
     };


### PR DESCRIPTION
﻿## 📝 Descrição
Corrige a validação de CPF do autocadastro para rejeitar CPFs formados por dígitos repetidos, como `000.000.000-00` e `111.111.111-11`.

A validação anterior conferia apenas o tamanho e os dígitos verificadores. Por isso, algumas sequências inválidas podiam ser aceitas porque passam matematicamente no cálculo dos verificadores.

Também foi adicionada uma suíte unitária dedicada ao validador para cobrir CPF válido, CPF mascarado, tamanho incorreto, dígito verificador inválido e sequências repetidas.

## 🛠 Tipo de Mudança
- 🐛 **FIX**: Correção de bug.

## 🧪 Guia de Testes
**Como reproduzir:**
1. Acessar o formulário de autocadastro.
2. Informar um CPF com todos os dígitos repetidos, por exemplo `000.000.000-00`.
3. Verificar que o campo passa a ser marcado como inválido.

**Resultado esperado:**
- CPFs compostos por dígitos repetidos devem ser rejeitados.
- CPFs válidos, com ou sem máscara, continuam sendo aceitos.

**Validações executadas:**
- `npm run build`
- `npx ng test --watch=false --browsers=ChromeHeadless --include=src/app/shared/utils/cpf-validator.spec.ts --progress=false`

## 📸 Screenshots
Não aplicável.

EU VOU REMOVER ISSO AQUI DPS É PELA SOBREVIVÊNCIA APENAS
